### PR TITLE
chore: update to madwizard 0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8226,9 +8226,9 @@
       }
     },
     "node_modules/madwizard": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.8.12.tgz",
-      "integrity": "sha512-um1O9DWY4hgmVPD28otAqsBM4M/CUA1TScPHYw9xJbPDNXId2QhA2yunJ5/8ovVE5PTCpLYE60119fLaSsVRZg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.8.13.tgz",
+      "integrity": "sha512-ZECnL/fFK+2StUhmC8matynGBcr5Qgl3sWrC8ag8dkL2Qeu9A6m7CTyTN9hfloTobQ27N+z+qpNJfu+KmM6o2g==",
       "dependencies": {
         "chalk": "^5.0.1",
         "cli-highlight": "^2.1.11",
@@ -15111,7 +15111,60 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "madwizard": "^0.8.12"
+        "madwizard": "^0.9.0"
+      }
+    },
+    "plugins/plugin-madwizard/node_modules/chalk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "plugins/plugin-madwizard/node_modules/madwizard": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.9.0.tgz",
+      "integrity": "sha512-gVsz+MswAgUsQ+cm82wCU3EJ3oeirjBI0KdI3qCCVW/FQIXsHwuKR6dN/STrZKU3CBkNMY3trJZ3YZRL7IkOdw==",
+      "dependencies": {
+        "chalk": "^5.0.1",
+        "cli-highlight": "^2.1.11",
+        "debug": "^4.3.4",
+        "enquirer": "^2.3.6",
+        "env-paths": "^2.2.1",
+        "expand-home-dir": "^0.0.3",
+        "figures": "^4.0.1",
+        "front-matter": "^4.0.2",
+        "hast-util-raw": "^7.2.1",
+        "hast-util-to-mdast": "^8.3.1",
+        "hast-util-to-string": "^2.0.0",
+        "js-yaml": "^4.1.0",
+        "make-fetch-happen": "^10.1.7",
+        "mdast-util-to-markdown": "^1.3.0",
+        "mkdirp": "^1.0.4",
+        "ora": "^6.1.0",
+        "remark-directive": "^2.0.1",
+        "remark-frontmatter": "^4.0.1",
+        "remark-parse": "^10.0.1",
+        "remark-rehype": "^10.1.0",
+        "terminal-link": "^3.0.0",
+        "tmp": "^0.2.1",
+        "to-vfile": "^7.2.3",
+        "unified": "^10.1.2",
+        "unist-builder": "^3.0.0",
+        "unist-util-visit": "^4.1.0",
+        "unist-util-visit-parents": "^5.1.0",
+        "uuid": "^8.3.2",
+        "vfile": "^5.3.2",
+        "which": "^2.0.2",
+        "yargs-parser": "^21.0.1"
+      },
+      "bin": {
+        "madwizard": "bin/madwizard.js",
+        "mw": "bin/madwizard.js"
       }
     }
   },
@@ -15732,7 +15785,52 @@
     "@kui-shell/plugin-madwizard": {
       "version": "file:plugins/plugin-madwizard",
       "requires": {
-        "madwizard": "^0.8.12"
+        "madwizard": "^0.9.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+          "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
+        },
+        "madwizard": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.9.0.tgz",
+          "integrity": "sha512-gVsz+MswAgUsQ+cm82wCU3EJ3oeirjBI0KdI3qCCVW/FQIXsHwuKR6dN/STrZKU3CBkNMY3trJZ3YZRL7IkOdw==",
+          "requires": {
+            "chalk": "^5.0.1",
+            "cli-highlight": "^2.1.11",
+            "debug": "^4.3.4",
+            "enquirer": "^2.3.6",
+            "env-paths": "^2.2.1",
+            "expand-home-dir": "^0.0.3",
+            "figures": "^4.0.1",
+            "front-matter": "^4.0.2",
+            "hast-util-raw": "^7.2.1",
+            "hast-util-to-mdast": "^8.3.1",
+            "hast-util-to-string": "^2.0.0",
+            "js-yaml": "^4.1.0",
+            "make-fetch-happen": "^10.1.7",
+            "mdast-util-to-markdown": "^1.3.0",
+            "mkdirp": "^1.0.4",
+            "ora": "^6.1.0",
+            "remark-directive": "^2.0.1",
+            "remark-frontmatter": "^4.0.1",
+            "remark-parse": "^10.0.1",
+            "remark-rehype": "^10.1.0",
+            "terminal-link": "^3.0.0",
+            "tmp": "^0.2.1",
+            "to-vfile": "^7.2.3",
+            "unified": "^10.1.2",
+            "unist-builder": "^3.0.0",
+            "unist-util-visit": "^4.1.0",
+            "unist-util-visit-parents": "^5.1.0",
+            "uuid": "^8.3.2",
+            "vfile": "^5.3.2",
+            "which": "^2.0.2",
+            "yargs-parser": "^21.0.1"
+          }
+        }
       }
     },
     "@kui-shell/plugin-patternfly4-themes": {
@@ -21275,9 +21373,9 @@
       "integrity": "sha512-BQuhQxPuRl79J5zSXRP+uNzPOyZw2oFI9JLRQ80XswSvg21KMKNtQza9eF42rfI/3Z40RvzBdXgziEkudzjo8A=="
     },
     "madwizard": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.8.12.tgz",
-      "integrity": "sha512-um1O9DWY4hgmVPD28otAqsBM4M/CUA1TScPHYw9xJbPDNXId2QhA2yunJ5/8ovVE5PTCpLYE60119fLaSsVRZg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.8.13.tgz",
+      "integrity": "sha512-ZECnL/fFK+2StUhmC8matynGBcr5Qgl3sWrC8ag8dkL2Qeu9A6m7CTyTN9hfloTobQ27N+z+qpNJfu+KmM6o2g==",
       "requires": {
         "chalk": "^5.0.1",
         "cli-highlight": "^2.1.11",

--- a/plugins/plugin-madwizard/package.json
+++ b/plugins/plugin-madwizard/package.json
@@ -23,6 +23,6 @@
     "access": "public"
   },
   "dependencies": {
-    "madwizard": "^0.8.12"
+    "madwizard": "^0.9.0"
   }
 }

--- a/tests/plugin-madwizard/markdowns/guidebook-tree-model1.md
+++ b/tests/plugin-madwizard/markdowns/guidebook-tree-model1.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - snippets-in-tab3.md
+    - ./snippets/snippets-in-tab3.md
 ---
 
 <!-- You should see a tree view. This is the Imports.tsx component -->

--- a/tests/plugin-madwizard/markdowns/guidebook-tree-model2.md
+++ b/tests/plugin-madwizard/markdowns/guidebook-tree-model2.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - snippets-in-tab4.md
+    - ./snippets/snippets-in-tab4.md
 ---
 
 <!-- You should see a tree view. This is the Imports.tsx component -->

--- a/tests/plugin-madwizard/markdowns/guidebook-tree-model3.md
+++ b/tests/plugin-madwizard/markdowns/guidebook-tree-model3.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - snippets-in-tab5.md
+    - ./snippets/snippets-in-tab5.md
 ---
 
 <!-- You should see a tree view. This is the Imports.tsx component -->

--- a/tests/plugin-madwizard/markdowns/guidebook-tree-model4.md
+++ b/tests/plugin-madwizard/markdowns/guidebook-tree-model4.md
@@ -1,7 +1,7 @@
 ---
 imports:
-    - importd.md
-    - snippets-in-tab5.md
+    - ./snippets/importd.md
+    - ./snippets/snippets-in-tab5.md
 ---
 
 <!-- You should see a tree view. This is the Imports.tsx component -->

--- a/tests/plugin-madwizard/markdowns/guidebook-tree-model5.md
+++ b/tests/plugin-madwizard/markdowns/guidebook-tree-model5.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - snippets-in-tab6.md
+    - ./snippets/snippets-in-tab6.md
 ---
 
 ::imports

--- a/tests/plugin-madwizard/markdowns/guidebook-tree-model6.md
+++ b/tests/plugin-madwizard/markdowns/guidebook-tree-model6.md
@@ -1,8 +1,8 @@
 ---
 imports:
-    - importg.md
-    - importa.md
-    - importd.md
+    - ./snippets/importg.md
+    - ./snippets/importa.md
+    - ./snippets/importd.md
 ---
 
 ::imports

--- a/tests/plugin-madwizard/markdowns/guidebook-tree-model7.md
+++ b/tests/plugin-madwizard/markdowns/guidebook-tree-model7.md
@@ -1,8 +1,8 @@
 ---
 imports:
-    - importgg.md
-    - importaa.md
-    - importdd.md
+    - ./snippets/importgg.md
+    - ./snippets/importaa.md
+    - ./snippets/importdd.md
 ---
 
 ::imports

--- a/tests/plugin-madwizard/markdowns/snippets/importaa.md
+++ b/tests/plugin-madwizard/markdowns/snippets/importaa.md
@@ -1,1 +1,1 @@
-{% include "importa.md" %}
+{% include "./importa.md" %}

--- a/tests/plugin-madwizard/markdowns/snippets/importd.md
+++ b/tests/plugin-madwizard/markdowns/snippets/importd.md
@@ -1,9 +1,9 @@
 # DDD
 
 === "SubTab1"
-    --8<-- "importa.md"
-    --8<-- "importa.md"
-    --8<-- "importa.md"
+    --8<-- "./importa.md"
+    --8<-- "./importa.md"
+    --8<-- "./importa.md"
     
 === "SubTab2"
-    --8<-- "importb.md"
+    --8<-- "./importb.md"

--- a/tests/plugin-madwizard/markdowns/snippets/importdd.md
+++ b/tests/plugin-madwizard/markdowns/snippets/importdd.md
@@ -1,1 +1,1 @@
-{% include "importd.md" %}
+{% include "./importd.md" %}

--- a/tests/plugin-madwizard/markdowns/snippets/importf.md
+++ b/tests/plugin-madwizard/markdowns/snippets/importf.md
@@ -1,4 +1,4 @@
 ---
 imports:
-    - importd.md
+    - ./importd.md
 ---

--- a/tests/plugin-madwizard/markdowns/snippets/importgg.md
+++ b/tests/plugin-madwizard/markdowns/snippets/importgg.md
@@ -1,1 +1,1 @@
-{% include "importg.md" %}
+{% include "./importg.md" %}

--- a/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab0.md
+++ b/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab0.md
@@ -1,11 +1,11 @@
 AAA
 
---8<-- "importa.md"
+--8<-- "./importa.md"
 
 === "Tab1"
-    --8<-- "snippets-in-tab0a.md"
+    --8<-- "./snippets-in-tab0a.md"
 
 === "Tab2"
-    --8<-- "snippets-in-tab0b.md"
+    --8<-- "./snippets-in-tab0b.md"
 
 DDD

--- a/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab0a.md
+++ b/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab0a.md
@@ -1,4 +1,4 @@
 BBB
 
---8<-- "importb.md"
+--8<-- "./importb.md"
 

--- a/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab0b.md
+++ b/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab0b.md
@@ -1,4 +1,4 @@
---8<-- "importc.md"
+--8<-- "./importc.md"
 
 ???+ tip "TipTitle"
     TipContent

--- a/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab1.md
+++ b/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab1.md
@@ -2,7 +2,7 @@
 layout:
     1: right
 imports:
-    - importa.md
+    - ./importa.md
 ---
 
 ::imports
@@ -12,9 +12,9 @@ imports:
 AAA
 
 === "Tab1"
-    --8<-- "snippets-in-tab1a.md"
+    --8<-- "./snippets-in-tab1a.md"
 
 === "Tab2"
-    --8<-- "snippets-in-tab1b.md"
+    --8<-- "./snippets-in-tab1b.md"
 
 DDD

--- a/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab1a.md
+++ b/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab1a.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - importb.md
+    - ./importb.md
 ---
 
 BBB

--- a/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab1b.md
+++ b/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab1b.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - importc.md
+    - ./importc.md
 ---
 
 ???+ tip "TipTitle"

--- a/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab2.md
+++ b/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab2.md
@@ -1,9 +1,9 @@
 AAA
 
 === "Tab1"
-    --8<-- "snippets-in-tab1b.md"
+    --8<-- "./snippets-in-tab1b.md"
 
 === "Tab2"
-    --8<-- "snippets-in-tab1a.md"
+    --8<-- "./snippets-in-tab1a.md"
 
 DDD

--- a/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab3.md
+++ b/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab3.md
@@ -2,9 +2,9 @@
 layout:
     1: right
 imports:
-    - importa.md
-    - importe.md
-    - importf.md
+    - ./importa.md
+    - ./importe.md
+    - ./importf.md
 ---
 
 ::imports
@@ -14,9 +14,9 @@ imports:
 # AAA
 
 === "Tab1"
-    --8<-- "snippets-in-tab3a.md"
+    --8<-- "./snippets-in-tab3a.md"
 
 === "Tab2"
-    --8<-- "snippets-in-tab1b.md"
+    --8<-- "./snippets-in-tab1b.md"
 
 DDD

--- a/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab3a.md
+++ b/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab3a.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - importd.md
+    - ./importd.md
 ---
 
 BBBoo

--- a/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab4.md
+++ b/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab4.md
@@ -2,8 +2,8 @@
 layout:
     1: right
 imports:
-    - importa.md
-    - importe.md
+    - ./importa.md
+    - ./importe.md
 ---
 
 ::imports
@@ -13,9 +13,9 @@ imports:
 # AAA
 
 === "Tab1"
-    --8<-- "snippets-in-tab3a.md"
+    --8<-- "./snippets-in-tab3a.md"
 
 === "Tab2"
-    --8<-- "snippets-in-tab4b.md"
+    --8<-- "./snippets-in-tab4b.md"
 
 DDD

--- a/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab5.md
+++ b/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab5.md
@@ -2,8 +2,8 @@
 layout:
     1: right
 imports:
-    - importa.md
-    - importe.md
+    - ./importa.md
+    - ./importe.md
 ---
 
 ::imports
@@ -13,12 +13,12 @@ imports:
 # AAA
 
 === "Tab1"
-    --8<-- "snippets-in-tab3a.md"
+    --8<-- "./snippets-in-tab3a.md"
 
 === "Tab2"
-    --8<-- "snippets-in-tab4b.md"
+    --8<-- "./snippets-in-tab4b.md"
 
 === "Tab3"
-    --8<-- "snippets-in-tab5c.md"
+    --8<-- "./snippets-in-tab5c.md"
 
 DDD

--- a/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab5c.md
+++ b/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab5c.md
@@ -1,6 +1,6 @@
 ---
 imports:
-    - importd.md
+    - ./importd.md
 ---
 
 CCCoo

--- a/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab6.md
+++ b/tests/plugin-madwizard/markdowns/snippets/snippets-in-tab6.md
@@ -1,11 +1,11 @@
 # Chooser
 
 === "Tab1"
-    :import{importd.md}
+    :import{./importd.md}
 
 === "Tab2"
-    :import{importd.md}
+    :import{./importd.md}
 
 === "Tab3"
-    :import{importd.md}
+    :import{./importd.md}
 


### PR DESCRIPTION
This includes the breaking change from madwizard: guidebook relative imports now need to use a `./` or `../` prefix to indicate that they are relative (rather than store-absolute) references.