### PR TITLE
fix: small optimization for initial load time of `guide` command

### DIFF
--- a/plugins/plugin-madwizard/src/plugin.ts
+++ b/plugins/plugin-madwizard/src/plugin.ts
@@ -15,7 +15,6 @@
  */
 
 import { Arguments, ParsedOptions, ReactResponse, Registrar, Tab } from "@kui-shell/core"
-import { setTabReadonly } from "./util"
 
 interface Options extends ParsedOptions {
   u: boolean
@@ -32,13 +31,14 @@ function withFilepath(
   return async ({ tab, argvNoOptions, parsedOptions }: Arguments<Options>) => {
     if (!parsedOptions.u) {
       // CLI path
-      const { CLI } = await import("madwizard")
-      await CLI.cli(["madwizard", task, ...argvNoOptions.slice(1)], undefined, { store: process.env.GUIDEBOOK_STORE })
+      const { cli } = await import("madwizard/dist/fe/cli/index.js")
+      await cli(["madwizard", task, ...argvNoOptions.slice(1)], undefined, { store: process.env.GUIDEBOOK_STORE })
       return true
     }
 
     // UI path
     if (readonly) {
+      const { setTabReadonly } = await import("./util")
       setTabReadonly({ tab })
     }
     return {

--- a/plugins/plugin-madwizard/src/read.ts
+++ b/plugins/plugin-madwizard/src/read.ts
@@ -16,5 +16,5 @@
 
 export default async function read(filepath: string) {
   const { Parser, reader } = await import("madwizard")
-  return Parser.blockify(filepath, await reader(), undefined, undefined, { store: process.env.GUIDEBOOK_STORE })
+  return Parser.parse(filepath, await reader(), undefined, undefined, { store: process.env.GUIDEBOOK_STORE })
 }


### PR DESCRIPTION
Try to load just the madwizard/cli, rather than all of madwizard (which loads lots of stuff we don't need for the initial execution in headless mode). It's possible that webpack has already optimized this away, but it's a small enough change...

This PR also updates the Guide.tsx component to avoid calling an internal API of madwizard/Parser