### PR TITLE
fix: codeflare cli should have a default guidebook

### DIFF
--- a/bin/codeflare
+++ b/bin/codeflare
@@ -118,7 +118,7 @@ do
     esac
 done
 
-if [ $# = 1 ] && [ "$1" != "version" ]; then
+if  [ $# = 0 ] || [ $# = 1 ] && [ "$1" != "version" ]; then
     # use the "guide" command if none was given
     EXTRAPREFIX="guide"
 fi

--- a/plugins/plugin-codeflare/src/plugin.ts
+++ b/plugins/plugin-codeflare/src/plugin.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-// import { Registrar } from '@kui-shell/core'
+import { Arguments, Registrar } from '@kui-shell/core'
+
+function help() {
+  return 'Usage: codeflare [run] [<task>] [-s /path/to/store] [-u]'
+}
 
 /** Register Kui Commands */
-export default function registerCodeflareCommands(/* registrar: Registrar */) {
-  /* e.g. this command will executable as "run"
-  registrar.listen('/run', args => {
-  })
-  */
+export default function registerCodeflareCommands(registrar: Registrar) {
+  registrar.listen('/help', help)
 }

--- a/plugins/plugin-madwizard/src/plugin.ts
+++ b/plugins/plugin-madwizard/src/plugin.ts
@@ -29,6 +29,10 @@ function withFilepath(
   cb: (filepath: string, tab: Tab) => Promise<true | ReactResponse["react"]>
 ) {
   return async ({ tab, argvNoOptions, parsedOptions }: Arguments<Options>) => {
+    if (!argvNoOptions[1]) {
+      argvNoOptions.push('ml/codeflare')
+    }
+
     if (!parsedOptions.u) {
       // CLI path
       const { cli } = await import("madwizard/dist/fe/cli/index.js")


### PR DESCRIPTION
we should play ml/codeflare by default, if the user does not specify a guidebook to run.