### PR TITLE
fix: support passing through -V verbose flag to madwizard

### DIFF
--- a/bin/codeflare
+++ b/bin/codeflare
@@ -110,17 +110,18 @@ fi
 # check if the user wants us to run the graphical version (currently
 # indicated by the -u option)
 do_cli=1
-while getopts "us:" opt
+while getopts "Vus:" opt
 do
     case $opt in
         (u) do_cli=0; shift; continue;;
         (s) GUIDEBOOK_STORE=$OPTARG; shift; shift; continue;;
+        (V) EXTRAPREFIX="-V"; shift; continue;;
     esac
 done
 
 if  [ $# = 0 ] || [ $# = 1 ] && [ "$1" != "version" ]; then
     # use the "guide" command if none was given
-    EXTRAPREFIX="guide"
+    EXTRAPREFIX="$EXTRAPREFIX guide"
 fi
 
 if [ "$do_cli" = "1" ]; then

--- a/plugins/plugin-madwizard/src/plugin.ts
+++ b/plugins/plugin-madwizard/src/plugin.ts
@@ -18,6 +18,8 @@ import { Arguments, ParsedOptions, ReactResponse, Registrar, Tab } from "@kui-sh
 
 interface Options extends ParsedOptions {
   u: boolean
+
+  V: boolean
 }
 
 // TODO export this from madwizard
@@ -36,7 +38,7 @@ function withFilepath(
     if (!parsedOptions.u) {
       // CLI path
       const { cli } = await import("madwizard/dist/fe/cli/index.js")
-      await cli(["madwizard", task, ...argvNoOptions.slice(1)], undefined, { store: process.env.GUIDEBOOK_STORE })
+      await cli(["madwizard", task, ...argvNoOptions.slice(1)], undefined, { store: process.env.GUIDEBOOK_STORE, verbose: parsedOptions.V })
       return true
     }
 
@@ -54,7 +56,7 @@ function withFilepath(
 /** Register Kui Commands */
 export default function registerMadwizardCommands(registrar: Registrar) {
   const flags = {
-    boolean: ["u"],
+    boolean: ["u", "V"],
   }
 
   registrar.listen(


### PR DESCRIPTION
```shell
codeflare -V ml/codeflare
```

the -V needs to be at the beginning