### PR TITLE
fix: support passing through --no-profile (via -n) option to madwizard

### DIFF
--- a/bin/codeflare
+++ b/bin/codeflare
@@ -110,14 +110,16 @@ fi
 # check if the user wants us to run the graphical version (currently
 # indicated by the -u option)
 do_cli=1
-while getopts "Vus:" opt
+while getopts "nVus:" opt
 do
     case $opt in
-        (u) do_cli=0; shift; continue;;
-        (s) GUIDEBOOK_STORE=$OPTARG; shift; shift; continue;;
-        (V) EXTRAPREFIX="-V"; shift; continue;;
+        (u) do_cli=0; continue;;
+        (s) GUIDEBOOK_STORE=$OPTARG; continue;;
+        (n) EXTRAPREFIX="$EXTRAPREFIX -n"; continue;;
+        (V) EXTRAPREFIX="$EXTRAPREFIX -V"; continue;;
     esac
 done
+shift $((OPTIND-1))
 
 if  [ $# = 0 ] || [ $# = 1 ] && [ "$1" != "version" ]; then
     # use the "guide" command if none was given

--- a/plugins/plugin-madwizard/src/plugin.ts
+++ b/plugins/plugin-madwizard/src/plugin.ts
@@ -17,9 +17,14 @@
 import { Arguments, ParsedOptions, ReactResponse, Registrar, Tab } from "@kui-shell/core"
 
 interface Options extends ParsedOptions {
+  /** Run in UI mode */
   u: boolean
 
+  /** verbose output */
   V: boolean
+
+  /** do not load prior choices (the default "profile") */
+  n: boolean
 }
 
 // TODO export this from madwizard
@@ -38,7 +43,7 @@ function withFilepath(
     if (!parsedOptions.u) {
       // CLI path
       const { cli } = await import("madwizard/dist/fe/cli/index.js")
-      await cli(["madwizard", task, ...argvNoOptions.slice(1)], undefined, { store: process.env.GUIDEBOOK_STORE, verbose: parsedOptions.V })
+      await cli(["madwizard", task, ...argvNoOptions.slice(1), ...(parsedOptions.n ? ['--no-profile'] : [])], undefined, { store: process.env.GUIDEBOOK_STORE, verbose: parsedOptions.V })
       return true
     }
 
@@ -56,7 +61,7 @@ function withFilepath(
 /** Register Kui Commands */
 export default function registerMadwizardCommands(registrar: Registrar) {
   const flags = {
-    boolean: ["u", "V"],
+    boolean: ["u", "V", "n"],
   }
 
   registrar.listen(


### PR DESCRIPTION
e.g.

```shell
codeflare -n -V ml/codeflare
```

which would run with no-profile mode (-n) meaning codeflare will not use remembered choices; and with verbose output (-V)