### PR TITLE
chore: run `npm run format`

### DIFF
--- a/plugins/plugin-client-default/src/index.tsx
+++ b/plugins/plugin-client-default/src/index.tsx
@@ -50,20 +50,19 @@ export default function renderMain(props: KuiProps) {
       productName={productName}
       lightweightTables
       {...props}
-    isPopup={false}
-    noTopTabs
-    guidebooks={false}
+      isPopup={false}
+      noTopTabs
+      guidebooks={false}
       quietExecCommand={false}
       toplevel={!Capabilities.inBrowser() && <Search />}
     >
       <ContextWidgets>
-      {/* <CurrentContext />
+        {/* <CurrentContext />
        <CurrentNamespace /> */}
       </ContextWidgets>
 
-      <SpaceFiller/>
-      <MeterWidgets>
-      </MeterWidgets>
+      <SpaceFiller />
+      <MeterWidgets></MeterWidgets>
     </Kui>
   )
 }

--- a/tests/common/startElectron.ts
+++ b/tests/common/startElectron.ts
@@ -17,8 +17,8 @@ function electronProductionPath() {
   return process.platform === "linux"
     ? productName
     : process.platform === "win32"
-      ? `${productName}.exe`
-      : join(productName + ".app", "Contents/MacOS", productName)
+    ? `${productName}.exe`
+    : join(productName + ".app", "Contents/MacOS", productName)
 }
 
 export default async function startElectron() {
@@ -27,8 +27,8 @@ export default async function startElectron() {
   const executablePath = !process.env.EXECUTABLE_PATH
     ? undefined
     : process.env.EXECUTABLE_PATH !== "github-actions-production"
-      ? process.env.EXECUTABLE_PATH
-      : join(
+    ? process.env.EXECUTABLE_PATH
+    : join(
         process.env.GITHUB_WORKSPACE,
         "dist/electron",
         `${productName}-${githubActionsOS()}-${githubActionsArch()}`,

--- a/tests/plugin-codeflare/dashboard/dashboard.ts
+++ b/tests/plugin-codeflare/dashboard/dashboard.ts
@@ -11,7 +11,6 @@ export default function doDashboard(directory: string) {
 
     await page.keyboard.type(`dashboard -f ${slash(relative(process.cwd(), join(__dirname, "./inputs", directory)))}`)
 
-
     await page.keyboard.press("Enter")
 
     const splitSelector = ".kui--terminal-split-container"

--- a/tests/plugin-codeflare/dashboard/inputs/1.spec.ts
+++ b/tests/plugin-codeflare/dashboard/inputs/1.spec.ts
@@ -1,3 +1,3 @@
-import doDashboard from "../dashboard";
+import doDashboard from "../dashboard"
 
 doDashboard("1")


### PR DESCRIPTION
we had a handful of commits where husky was not enabled, and so formatting was not performed