### PR TITLE
fix: chart title should be sans-serif

### DIFF
--- a/plugins/plugin-codeflare/web/scss/components/Dashboard/Charts.scss
+++ b/plugins/plugin-codeflare/web/scss/components/Dashboard/Charts.scss
@@ -22,6 +22,8 @@
   padding: 2em 1em;
   grid-template-columns: repeat(4, 1fr);
   grid-auto-rows: minmax(300px, max-content);
+
+  font-family: var(--font-sans-serif);
 }
 
 @include ChartContainer {


### PR DESCRIPTION
currently it is monospace