### PR TITLE
fix: first switch to Application source results in odd glitch

### DIFF
--- a/plugins/plugin-codeflare/src/components/Chart.tsx
+++ b/plugins/plugin-codeflare/src/components/Chart.tsx
@@ -145,7 +145,7 @@ export default class BaseChart extends React.PureComponent<Props> {
   private static readonly titlePosition = {
     x: {
       left: BaseChart.padding.left - BaseChart.tickLabelFontSize * 4,
-      right: BaseChart.dimensions.width - BaseChart.tickLabelFontSize * 1.5,
+      right: BaseChart.dimensions.width - BaseChart.tickLabelFontSize * 2,
     },
     y: BaseChart.padding.top - BaseChart.fontSize * 1.5,
   }

--- a/plugins/plugin-codeflare/web/scss/components/Dashboard/_index.scss
+++ b/plugins/plugin-codeflare/web/scss/components/Dashboard/_index.scss
@@ -31,7 +31,7 @@
   @include Split(3) {
     /* @include Rows(7); */
     @include Columns(13);
-    grid-template-rows: repeat(3, minmax(9vmax, auto)) repeat(4, auto);
+    grid-template-rows: repeat(3, 10vmax) repeat(4, auto);
     grid-template-areas:
       "T1 T1 T1 T3 T3 T3 T3 T3 T3 T3 T3 T3 T3"
       "T1 T1 T1 T3 T3 T3 T3 T3 T3 T3 T3 T3 T3"


### PR DESCRIPTION
the height of the lower right split changes momentarily (as presumably monaco-editor loads for the first time)