### PR TITLE
feat: Terminal content search feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14981,6 +14981,14 @@
         "xterm": "^4.0.0"
       }
     },
+    "node_modules/xterm-addon-search": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-search/-/xterm-addon-search-0.9.0.tgz",
+      "integrity": "sha512-aoolI8YuHvdGw+Qjg8g2M4kst0v86GtB7WeBm4F0jNXA005/6QbWWy9eCsvnIDLJOFI5JSSrZnD6CaOkvBQYPA==",
+      "peerDependencies": {
+        "xterm": "^4.0.0"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -15112,7 +15120,8 @@
         "@patternfly/react-charts": "^6.74.3",
         "@patternfly/react-core": "^4.221.3",
         "split2": "^4.1.0",
-        "strip-ansi": "6.0.0"
+        "strip-ansi": "6.0.0",
+        "xterm-addon-search": "^0.9.0"
       }
     },
     "plugins/plugin-codeflare/node_modules/strip-ansi": {
@@ -15708,7 +15717,8 @@
         "@patternfly/react-charts": "^6.74.3",
         "@patternfly/react-core": "^4.221.3",
         "split2": "^4.1.0",
-        "strip-ansi": "6.0.0"
+        "strip-ansi": "6.0.0",
+        "xterm-addon-search": "^0.9.0"
       },
       "dependencies": {
         "strip-ansi": {
@@ -26174,6 +26184,12 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.5.0.tgz",
       "integrity": "sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ==",
+      "requires": {}
+    },
+    "xterm-addon-search": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-search/-/xterm-addon-search-0.9.0.tgz",
+      "integrity": "sha512-aoolI8YuHvdGw+Qjg8g2M4kst0v86GtB7WeBm4F0jNXA005/6QbWWy9eCsvnIDLJOFI5JSSrZnD6CaOkvBQYPA==",
       "requires": {}
     },
     "y18n": {

--- a/plugins/plugin-codeflare/package.json
+++ b/plugins/plugin-codeflare/package.json
@@ -27,6 +27,7 @@
     "@patternfly/react-charts": "^6.74.3",
     "@patternfly/react-core": "^4.221.3",
     "split2": "^4.1.0",
-    "strip-ansi": "6.0.0"
+    "strip-ansi": "6.0.0",
+    "xterm-addon-search": "^0.9.0"
   }
 }

--- a/plugins/plugin-codeflare/web/scss/components/Terminal/_index.scss
+++ b/plugins/plugin-codeflare/web/scss/components/Terminal/_index.scss
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import "mixins";
+
+@include CodeFlareToolbar {
+  padding: 0;
+
+  @include SearchIcon {
+    z-index: 10;
+  }
+}

--- a/plugins/plugin-codeflare/web/scss/components/Terminal/_mixins.scss
+++ b/plugins/plugin-codeflare/web/scss/components/Terminal/_mixins.scss
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@mixin CodeFlareToolbar {
+  .codeflare--toolbar {
+    @content;
+  }
+}
+
+@mixin SearchIcon {
+  .pf-c-text-input-group__icon {
+    @content;
+  }
+}


### PR DESCRIPTION
This PR introduces a search box below the application logs. It allows for searching.

Fixes #179 

Though that issue asks for filtering, and this provides search capability, I'll close that issue, for now. In order to do filtering, we would need to write an xterm.js addon. There is already an `xterm-addon-search`, but no `xterm-addon-filter`. See: https://github.com/xtermjs/xterm.js/tree/master/addons

<img width="1392" alt="codeflare dashboard with search" src="https://user-images.githubusercontent.com/4741620/177387493-e8a1266b-8fb8-4fda-8da8-004770263d6f.png">
