### PR TITLE
fix: remove `stty sane` from bin/codeflare launcher

### DIFF
--- a/bin/codeflare
+++ b/bin/codeflare
@@ -166,4 +166,3 @@ fi
 
 # otherwise, we launch the UI version
 "$NODE" "$HEADLESS"/codeflare.min.js -- $EXTRAPREFIX $*
-stty sane


### PR DESCRIPTION
We needed this while we were using `listr2`. As we no longer use `listr2`, this hack is no longer needed.