### PR TITLE
feat: codeflare attach command

### DIFF
--- a/bin/codeflare
+++ b/bin/codeflare
@@ -126,7 +126,8 @@ if [ $use_docker = 1 ]; then
     exec docker run -it --entrypoint ${ENTRYPOINT-codeflare} --rm -v /tmp:/tmp -v ~/.aws:/home/codeflare/.aws -v ~/.bluemix:/home/codeflare/.bluemix -v ~/.kube:/home/codeflare/.kube -e KUBECONFIG=$(echo $KUBECONFIG | sed "s/$USER/codeflare/g" | sed 's/Users/home/g') ghcr.io/project-codeflare/codeflare-cli -- $*
 fi
 
-if  ([ $do_cli = 1 ] && [ $# = 0 ]) || ([ $# = 1 ] && [ "$1" != "version" ]); then
+if  ([ $do_cli = 1 ] && [ $# = 0 ]) || ([ $# = 1 ] && [ "$1" != "version" ] && [ "$1" != "attach" ]); then
+    # TODO make this a kui command catchall
     # use the "guide" command if none was given
     EXTRAPREFIX="$EXTRAPREFIX guide"
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@types/react": "17.0.39",
         "@types/react-dom": "17.0.11",
         "@types/split2": "^3.2.1",
+        "@types/tmp": "^0.2.3",
         "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.30.5",
         "@typescript-eslint/parser": "^5.30.5",
@@ -1509,6 +1510,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
+      "dev": true
     },
     "node_modules/@types/unist": {
       "version": "2.0.6",
@@ -15133,6 +15140,7 @@
         "pretty-bytes": "^6.0.0",
         "split2": "^4.1.0",
         "strip-ansi": "6.0.0",
+        "tmp": "^0.2.1",
         "xterm-addon-search": "^0.9.0"
       }
     },
@@ -15731,6 +15739,7 @@
         "pretty-bytes": "^6.0.0",
         "split2": "^4.1.0",
         "strip-ansi": "6.0.0",
+        "tmp": "^0.2.1",
         "xterm-addon-search": "^0.9.0"
       },
       "dependencies": {
@@ -16397,6 +16406,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
+      "dev": true
     },
     "@types/unist": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@types/react": "17.0.39",
     "@types/react-dom": "17.0.11",
     "@types/split2": "^3.2.1",
+    "@types/tmp": "^0.2.3",
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",

--- a/plugins/plugin-codeflare/package.json
+++ b/plugins/plugin-codeflare/package.json
@@ -29,6 +29,7 @@
     "pretty-bytes": "^6.0.0",
     "split2": "^4.1.0",
     "strip-ansi": "6.0.0",
+    "tmp": "^0.2.1",
     "xterm-addon-search": "^0.9.0"
   }
 }

--- a/plugins/plugin-codeflare/src/controller/attach.ts
+++ b/plugins/plugin-codeflare/src/controller/attach.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { dir } from "tmp"
+import { cli } from "madwizard/dist/fe/cli"
+import { Arguments, KResponse } from "@kui-shell/core"
+
+export default async function attach(args: Arguments) {
+  return new Promise<KResponse>((resolve, reject) => {
+    dir(async (err, logdir) => {
+      if (err) {
+        reject(err)
+      }
+
+      process.env.LOGDIR_STAGE = logdir
+      await cli(["codeflare", "guide", "ml/ray/aggregator"], undefined, { store: process.env.GUIDEBOOK_STORE })
+      resolve(args.REPL.qexec(`codeflare dashboard ${logdir}`))
+    })
+  })
+}

--- a/plugins/plugin-codeflare/src/controller/index.ts
+++ b/plugins/plugin-codeflare/src/controller/index.ts
@@ -26,6 +26,7 @@ import description from "./description"
 function help() {
   return `Usage:
 codeflare [run] [<task>] [-s /path/to/store] [-u]
+codeflare attach
 codeflare dashboard /path/to/logdir
 codeflare chart gpu /path/to/logdir`
 }
@@ -33,6 +34,7 @@ codeflare chart gpu /path/to/logdir`
 /** Register Kui Commands */
 export default function registerCodeflareCommands(registrar: Registrar) {
   tailf(registrar)
+  registrar.listen("/attach", (args) => import("./attach").then((_) => _.default(args)))
   browse(registrar)
   charts(registrar)
   events(registrar)


### PR DESCRIPTION
This command executes the `ml/ray/aggregator` guidebook, and then launches the dashboard against the aggregator's staging directory.

TODO: the underlying aggregator guidebooks are still teeing to the console. We need to inhibit this somehow.