### PR TITLE
fix: tray menu support gives command an exception in headless mode

### DIFF
--- a/plugins/plugin-codeflare/src/tray.ts
+++ b/plugins/plugin-codeflare/src/tray.ts
@@ -85,14 +85,16 @@ export async function main(/* createWindow: (argv: string[]) => void */) {
 }
 
 export async function renderer(ipcRenderer: import("electron").IpcRenderer) {
-  ipcRenderer.send(
-    "/exec/invoke",
-    JSON.stringify({
-      module: "plugin-codeflare",
-      main: "initTray",
-      args: {
-        command: "/tray/init",
-      },
-    })
-  )
+  if (ipcRenderer) {
+    ipcRenderer.send(
+      "/exec/invoke",
+      JSON.stringify({
+        module: "plugin-codeflare",
+        main: "initTray",
+        args: {
+          command: "/tray/init",
+        },
+      })
+    )
+  }
 }


### PR DESCRIPTION
seems innocuous, but alarming