### PR TITLE
chore: code cleanup to avoid too much magic in the bin/codeflare shell script

### DIFF
--- a/bin/codeflare
+++ b/bin/codeflare
@@ -116,21 +116,15 @@ do
     case $opt in
         d) use_docker=1; continue;;
         u) do_cli=0; continue;;
-        s) GUIDEBOOK_STORE=$OPTARG; continue;;
-        *) EXTRAPREFIX="$EXTRAPREFIX -$opt"; continue;;
+        s) export GUIDEBOOK_STORE=$OPTARG; continue;;
+        *) continue;;
     esac
 done
-shift $((OPTIND-1))
+# shift $((OPTIND-1))
 
 if [ $use_docker = 1 ]; then
     # launch inside a docker container
     exec docker run -it --entrypoint ${ENTRYPOINT-codeflare} --rm -v /tmp:/tmp -v ~/.aws:/home/codeflare/.aws -v ~/.bluemix:/home/codeflare/.bluemix -v ~/.kube:/home/codeflare/.kube -e KUBECONFIG=$(echo $KUBECONFIG | sed "s/$USER/codeflare/g" | sed 's/Users/home/g') ghcr.io/project-codeflare/codeflare-cli -- $*
-fi
-
-if  ([ $do_cli = 1 ] && [ $# = 0 ]) || ([ $# = 1 ] && [ "$1" != "version" ] && [ "$1" != "attach" ]); then
-    # TODO make this a kui command catchall
-    # use the "guide" command if none was given
-    EXTRAPREFIX="$EXTRAPREFIX guide"
 fi
 
 if [ "$do_cli" = "1" ]; then
@@ -140,14 +134,6 @@ if [ "$do_cli" = "1" ]; then
     export KUI_HEADLESS=true
     export KUI_S3=false # we don't need plugin-s3 capabilities when in headless mode
     export ELECTRON_RUN_AS_NODE=true
-#    export MWSTORE="$GUIDEBOOK_STORE"
-#    exec "$NODE" \
-#         --experimental-specifier-resolution=node --no-warnings --experimental-import-meta-resolve \
-#         "$HEADLESS"/../../node_modules/madwizard/bin/madwizard.js \
-#         $*
-elif [ $# -gt 0 ]; then
-    # tell the command handlers to run in UI mode
-    EXTRAPREFIX="$EXTRAPREFIX -u"
 fi
 
 # Linux may not have the prereqs needed to run Electron
@@ -176,4 +162,4 @@ fi
 trap 'pkill -P $$; exit 1;' TERM INT
 
 # otherwise, we launch the UI version
-"$NODE" "$HEADLESS"/codeflare.min.js -- $EXTRAPREFIX $*
+"$NODE" "$HEADLESS"/codeflare.min.js -- codeflare $EXTRAPREFIX "$@"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "postinstall": "npm run compile",
     "format": "prettier --write '**/*.{scss,css,html,js,json,md,ts,tsx}'",
     "lint": "eslint . --ext '**/*.{js,ts,tsx}'",
-    "open": "./bin/codeflare -u",
+    "open": "./bin/codeflare hello",
     "start": "WATCH_ARGS='-open' npm run watch",
     "mirror": "cross-env rm -rf tmp && cross-env git clone --depth=1 https://github.com/guidebooks/store.git $PWD/tmp/store && cross-env madwizard mirror $PWD/tmp/store/guidebooks $PWD/store && rm -rf tmp",
     "mirror-if-needed": "if [ ! -d ./store ]; then npm run mirror; fi",

--- a/plugins/plugin-client-default/notebooks/dashboard-summary.md
+++ b/plugins/plugin-client-default/notebooks/dashboard-summary.md
@@ -5,5 +5,5 @@
     execute: now
     outputOnly: true
     ---
-    description $LOGDIR/job.json
+    codeflare description $LOGDIR/job.json
     ```

--- a/plugins/plugin-client-default/notebooks/dashboard.md
+++ b/plugins/plugin-client-default/notebooks/dashboard.md
@@ -24,7 +24,7 @@ layout:
     execute: now
     outputOnly: true
     ---
-    description application "$LOGDIR"
+    codeflare description application "$LOGDIR"
     ```
 
 === "Workers"
@@ -34,7 +34,7 @@ layout:
     execute: now
     outputOnly: true
     ---
-    description workers "$LOGDIR"
+    codeflare description workers "$LOGDIR"
     ```
 
 ---
@@ -87,7 +87,7 @@ layout:
     maximize: true
     outputOnly: true
     ---
-    chart all "${LOGDIR}"
+    codeflare chart all "${LOGDIR}"
     ```
 
 ---
@@ -98,5 +98,5 @@ layout:
     execute: now
     outputOnly: true
     ---
-    chart events "${LOGDIR}"
+    codeflare chart events "${LOGDIR}"
     ```

--- a/plugins/plugin-client-default/src/index.tsx
+++ b/plugins/plugin-client-default/src/index.tsx
@@ -59,11 +59,7 @@ export default function renderMain(props: KuiProps) {
       initialTabTitle="Welcome"
       isPopup={false}
       quietExecCommand={false}
-      commandLine={
-        process.env.RUNNING_KUI_TEST
-          ? undefined
-          : props.commandLine || ["commentary", "--readonly", "-f", "/kui/client/welcome.md"]
-      }
+      commandLine={process.env.RUNNING_KUI_TEST ? undefined : props.commandLine || ["codeflare", "hello"]}
     >
       <ContextWidgets>
         <GitHubIcon />

--- a/plugins/plugin-codeflare/src/controller/catchall.ts
+++ b/plugins/plugin-codeflare/src/controller/catchall.ts
@@ -14,5 +14,6 @@
  * limitations under the License.
  */
 
-export { setTabReadonly } from "./util"
-export { doMadwizard, Options as MadWizardOptions } from "./plugin"
+import { doMadwizard } from "@kui-shell/plugin-madwizard"
+
+export default doMadwizard(true, "guide", true)

--- a/plugins/plugin-codeflare/src/controller/charts/all.tsx
+++ b/plugins/plugin-codeflare/src/controller/charts/all.tsx
@@ -86,7 +86,7 @@ async function offline(filepath: string, REPL: Arguments["REPL"]): Promise<React
  *
  */
 export default async function all(args: Arguments) {
-  const filepath = args.argvNoOptions[2]
+  const filepath = args.argvNoOptions[3]
   if (!filepath) {
     throw new Error(`Usage chart all ${filepath}`)
   }

--- a/plugins/plugin-codeflare/src/controller/charts/gpu.tsx
+++ b/plugins/plugin-codeflare/src/controller/charts/gpu.tsx
@@ -82,7 +82,7 @@ function chart(logs: Awaited<ReturnType<typeof parse>>): ReactResponse {
 }
 
 export default async function chartCmd(args: Arguments) {
-  const filepath = args.argvNoOptions[2]
+  const filepath = args.argvNoOptions[3]
   if (!filepath) {
     throw new Error(`Usage chart vmstat ${filepath}`)
   }

--- a/plugins/plugin-codeflare/src/controller/charts/index.ts
+++ b/plugins/plugin-codeflare/src/controller/charts/index.ts
@@ -18,7 +18,9 @@ import { Registrar } from "@kui-shell/core"
 
 /** Register Kui Commands */
 export default function registerCodeflareCommands(registrar: Registrar) {
-  registrar.listen("/chart/gpu", (args) => import("./gpu").then((_) => _.default(args)), { needsUI: true })
-  registrar.listen("/chart/vmstat", (args) => import("./vmstat").then((_) => _.default(args)), { needsUI: true })
-  registrar.listen("/chart/all", (args) => import("./all").then((_) => _.default(args)), { needsUI: true })
+  registrar.listen("/codeflare/chart/gpu", (args) => import("./gpu").then((_) => _.default(args)), { needsUI: true })
+  registrar.listen("/codeflare/chart/vmstat", (args) => import("./vmstat").then((_) => _.default(args)), {
+    needsUI: true,
+  })
+  registrar.listen("/codeflare/chart/all", (args) => import("./all").then((_) => _.default(args)), { needsUI: true })
 }

--- a/plugins/plugin-codeflare/src/controller/charts/vmstat.tsx
+++ b/plugins/plugin-codeflare/src/controller/charts/vmstat.tsx
@@ -81,7 +81,7 @@ function chart(logs: Awaited<ReturnType<typeof parse>>): ReactResponse {
 }
 
 export default async function chartCmd(args: Arguments) {
-  const filepath = args.argvNoOptions[2]
+  const filepath = args.argvNoOptions[3]
   if (!filepath) {
     throw new Error(`Usage chart vmstat ${filepath}`)
   }

--- a/plugins/plugin-codeflare/src/controller/dashboard.ts
+++ b/plugins/plugin-codeflare/src/controller/dashboard.ts
@@ -39,7 +39,7 @@ function dashboardcli(args: Arguments<DashboardOptions>) {
     return import("./attach").then((_) => _.default(args))
   }
 
-  const filepath = args.argvNoOptions[1]
+  const filepath = args.argvNoOptions[2]
   if (!filepath) {
     throw new Error("Usage: codeflare dashboard <filepath>")
   }
@@ -67,7 +67,7 @@ export const height = 960
 export default function registerDashboardCommands(registrar: Registrar) {
   const flags = followFlags
 
-  ;["dashboard", "db"].forEach((db) => registrar.listen(`/${db}`, dashboardcli, { flags, outputOnly: true }))
+  ;["dashboard", "db"].forEach((db) => registrar.listen(`/codeflare/${db}`, dashboardcli, { flags, outputOnly: true }))
 
   registrar.listen("/codeflare/dashboardui", dashboardui, {
     hidden: true,

--- a/plugins/plugin-codeflare/src/controller/description.ts
+++ b/plugins/plugin-codeflare/src/controller/description.ts
@@ -57,7 +57,7 @@ export async function getJobDefinition(runDir: string, REPL: Arguments["REPL"]) 
 }
 
 async function app(args: Arguments) {
-  const filepath = args.argvNoOptions[2]
+  const filepath = args.argvNoOptions[3]
   if (!filepath) {
     throw new Error("Usage: description application <filepath>")
   }
@@ -83,7 +83,7 @@ async function app(args: Arguments) {
 }
 
 async function workers(args: Arguments) {
-  const filepath = args.argvNoOptions[2]
+  const filepath = args.argvNoOptions[3]
   if (!filepath) {
     throw new Error("Usage: description workers <filepath>")
   }
@@ -108,6 +108,6 @@ async function workers(args: Arguments) {
 }
 
 export default function registerDescriptionCommands(registrar: Registrar) {
-  registrar.listen("/description/application", app, { needsUI: true })
-  registrar.listen("/description/workers", workers, { needsUI: true })
+  registrar.listen("/codeflare/description/application", app, { needsUI: true })
+  registrar.listen("/codeflare/description/workers", workers, { needsUI: true })
 }

--- a/plugins/plugin-codeflare/src/controller/events/Events.tsx
+++ b/plugins/plugin-codeflare/src/controller/events/Events.tsx
@@ -17,7 +17,7 @@
 import React from "react"
 import { join } from "path"
 import stripAnsi from "strip-ansi"
-import { Arguments } from "@kui-shell/core"
+import { Arguments, encodeComponent } from "@kui-shell/core"
 
 import { GenericEvent } from "./Event"
 import parseKubeEvents, { collateEvent as collateKubeEvent, KubeEvent } from "./kube"
@@ -228,11 +228,11 @@ async function eventsUI(filepath: string, REPL: Arguments["REPL"]) {
     )
   } else {
     const [kube, torch] = await Promise.all([
-      REPL.qexec<string>(`vfs fslice ${kubeFilepath} 0`)
+      REPL.qexec<string>(`vfs fslice ${encodeComponent(kubeFilepath)} 0`)
         .catch(() => "")
         .then(stripAnsi)
         .then(parseKubeEvents),
-      REPL.qexec<string>(`vfs fslice ${jobFilepath} 0`)
+      REPL.qexec<string>(`vfs fslice ${encodeComponent(jobFilepath)} 0`)
         .catch(() => "")
         .then(stripAnsi)
         .then(parseTorchEvents),
@@ -243,9 +243,9 @@ async function eventsUI(filepath: string, REPL: Arguments["REPL"]) {
 }
 
 export default async function eventsCmd(args: Arguments) {
-  const filepath = args.argvNoOptions[2]
+  const filepath = args.argvNoOptions[3]
   if (!filepath) {
-    throw new Error(`Usage chart progress ${filepath}`)
+    throw new Error(`Usage codeflare chart events ${filepath}`)
   }
 
   return {

--- a/plugins/plugin-codeflare/src/controller/events/index.ts
+++ b/plugins/plugin-codeflare/src/controller/events/index.ts
@@ -18,5 +18,7 @@ import { Registrar } from "@kui-shell/core"
 
 /** Command registration part of the Events UI */
 export default function registerEventCommands(registrar: Registrar) {
-  registrar.listen("/chart/events", (args) => import("./Events").then((_) => _.default(args)), { needsUI: true })
+  registrar.listen("/codeflare/chart/events", (args) => import("./Events").then((_) => _.default(args)), {
+    needsUI: true,
+  })
 }

--- a/plugins/plugin-codeflare/src/controller/index.ts
+++ b/plugins/plugin-codeflare/src/controller/index.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Registrar } from "@kui-shell/core"
+import { KResponse, Registrar } from "@kui-shell/core"
+import { MadWizardOptions } from "@kui-shell/plugin-madwizard"
 
 import tailf from "./tailf"
 import browse from "./browse"
@@ -44,4 +45,16 @@ export default function registerCodeflareCommands(registrar: Registrar) {
     needsUI: true,
   })
   registrar.listen("/codeflare/get/run", (args) => import("./run/get").then((_) => _.default(args)), { needsUI: true })
+
+  // launch our hello guidebook
+  registrar.listen("/codeflare/hello", (args) => args.REPL.qexec("commentary --readonly -f /kui/client/welcome.md"), {
+    needsUI: true,
+    outputOnly: true,
+  })
+
+  registrar.catchall<KResponse, MadWizardOptions>(
+    (argv: string[]) => argv[1] === "codeflare",
+    (args) => import("./catchall").then((_) => _.default(args)),
+    0
+  )
 }

--- a/plugins/plugin-madwizard/src/plugin.ts
+++ b/plugins/plugin-madwizard/src/plugin.ts
@@ -16,7 +16,7 @@
 
 import { Arguments, ParsedOptions, ReactResponse, Registrar, Tab } from "@kui-shell/core"
 
-interface Options extends ParsedOptions {
+export interface Options extends ParsedOptions {
   /** Run in UI mode */
   u: boolean
 
@@ -42,7 +42,7 @@ interface Options extends ParsedOptions {
 // TODO export this from madwizard
 type Task = "profile" | "guide" | "plan"
 
-function doMadwizard(
+export function doMadwizard(
   readonly: boolean,
   task: Task,
   withFilepath = false,


### PR DESCRIPTION
Push this complexity to a kui catchall command registration. We want `codeflare ml/codeflare` to open in guide mode. We do this, in this PR, by using a Kui catchall, catching all unknown command lines that start with `codeflare ...`. With this in place, we can remove some of the junk in the bin/codeflare shell script.

This PR also fixes a number of bugs with handling of spaces in filepaths. Why add this to this PR? Because we need to update bin/codeflare to use "$@" to fix spaces... This requires us to add `codeflare ` as a prefix, which leads to the catchall ...