### PR TITLE
fix: header text should be darker and bigger

### DIFF
--- a/plugins/plugin-client-default/web/scss/components/Client.scss
+++ b/plugins/plugin-client-default/web/scss/components/Client.scss
@@ -34,6 +34,14 @@
     }
   }
 
+  /** Note: not just HeaderName; we need to prioritize over some built-in Kui css rules */
+  @include HeaderNameContainer {
+    @include HeaderName {
+      font-size: 1.125em;
+      color: var(--color-text-01);
+    }
+  }
+
   @include HeaderName {
     width: 100%;
     justify-content: center;


### PR DESCRIPTION
we are using kui's default `var(--color-text-02)`