### PR TITLE
fix: codeflare catchall does not fire

### DIFF
--- a/plugins/plugin-codeflare/src/controller/catchall.ts
+++ b/plugins/plugin-codeflare/src/controller/catchall.ts
@@ -16,4 +16,7 @@
 
 import { doMadwizard } from "@kui-shell/plugin-madwizard"
 
+/**
+ * Our catch-all command handler: send to madwizard.
+ */
 export default doMadwizard(true, "guide", true)

--- a/plugins/plugin-codeflare/src/controller/index.ts
+++ b/plugins/plugin-codeflare/src/controller/index.ts
@@ -54,9 +54,13 @@ export default function registerCodeflareCommands(registrar: Registrar) {
     height: 600,
   })
 
+  /**
+   * Register a catch-all command handler: any `/^codeflare/` command
+   * lines, send to madwizard.
+   */
   registrar.catchall<KResponse, MadWizardOptions>(
-    (argv: string[]) => argv[1] === "codeflare",
+    (argv: string[]) => argv[0] === "codeflare",
     (args) => import("./catchall").then((_) => _.default(args)),
-    0
+    1
   )
 }


### PR DESCRIPTION
Oof, our filter was checking argv[1]===codeflare, instead of argv[0]