### PR TITLE
feat: change --auto to --yes

### DIFF
--- a/bin/codeflare
+++ b/bin/codeflare
@@ -111,7 +111,7 @@ fi
 # indicated by the -u option)
 do_cli=1
 use_docker=0
-while getopts "iqadnVus:" opt
+while getopts "iqaydnVus:" opt
 do
     case $opt in
         d) use_docker=1; continue;;

--- a/plugins/plugin-codeflare/src/controller/attach.ts
+++ b/plugins/plugin-codeflare/src/controller/attach.ts
@@ -19,7 +19,11 @@ import { MadWizardOptions } from "madwizard"
 import { Arguments, encodeComponent } from "@kui-shell/core"
 
 export default async function attach(args: Arguments) {
-  const options: MadWizardOptions = { store: process.env.GUIDEBOOK_STORE, clean: false }
+  const options: MadWizardOptions = {
+    store: process.env.GUIDEBOOK_STORE,
+    clean: false,
+    interactive: args.parsedOptions.i || !args.parsedOptions.y,
+  }
 
   // TODO: update madwizard to accept env in the options
   process.env.NO_WAIT = "true" // don't wait for job termination

--- a/plugins/plugin-madwizard/src/plugin.ts
+++ b/plugins/plugin-madwizard/src/plugin.ts
@@ -31,8 +31,8 @@ export interface Options extends ParsedOptions {
   quiet: boolean
 
   /** Automatically accept all choices from the current profile */
-  a: boolean
-  auto: boolean
+  y: boolean
+  yes: boolean
 
   /** Interactive guide mode? [default: false] */
   i: boolean
@@ -74,7 +74,7 @@ export function doMadwizard(
         {
           store: process.env.GUIDEBOOK_STORE,
           verbose: parsedOptions.V,
-          interactive: parsedOptions.i || !parsedOptions.a,
+          interactive: parsedOptions.i || !parsedOptions.y,
         }
       )
       return true
@@ -98,8 +98,8 @@ export function doMadwizard(
 /** Register Kui Commands */
 export default function registerMadwizardCommands(registrar: Registrar) {
   const flags = {
-    boolean: ["u", "V", "n", "q", "i", "a"],
-    alias: { quiet: ["q"], interactive: ["i"], auto: ["a"] },
+    boolean: ["u", "V", "n", "q", "i", "y"],
+    alias: { quiet: ["q"], interactive: ["i"], yes: ["y"] },
   }
 
   registrar.listen("/profile", doMadwizard(true, "profile"))


### PR DESCRIPTION
We have been using `-a` to mean two things: --auto as in non-interactive guide run, and also `-a` to mean "attach" for dashboard operations. This makes it impossible to attach a dashboard in non-interactive mode.