### PR TITLE
feat: flatten the tray menu a bit

### DIFF
--- a/plugins/plugin-codeflare/src/tray/menus/index.ts
+++ b/plugins/plugin-codeflare/src/tray/menus/index.ts
@@ -33,7 +33,7 @@ export default async function buildContextMenu(
   const contextMenu = Menu.buildFromTemplate([
     { label: `Open CodeFlare`, click: () => createWindow([]) },
     { type: "separator" },
-    await profilesMenu(createWindow, updateFn),
+    ...(await profilesMenu(createWindow, updateFn)),
     { type: "separator" },
     { label: `Version ${version}`, enabled: false },
     { label: `About CodeFlare`, click: () => import("open").then((_) => _.default(homepage)) },

--- a/plugins/plugin-codeflare/src/tray/menus/runs.ts
+++ b/plugins/plugin-codeflare/src/tray/menus/runs.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { MenuItemConstructorOptions } from "electron"
 import { Profiles } from "madwizard"
 import { CreateWindowFunction } from "@kui-shell/core"
@@ -18,7 +34,7 @@ function openRun(runId: string, createWindow: CreateWindowFunction) {
 }
 
 /** @return files of the directory of job runs for a given profile */
-export async function readRunsDir(): Promise<string[]> {
+async function readRunsDir(): Promise<string[]> {
   try {
     const runsDir = Profiles.guidebookJobDataPath({})
     return await readdir(runsDir)
@@ -28,6 +44,17 @@ export async function readRunsDir(): Promise<string[]> {
 }
 
 /** @return a menu for all runs of a profile */
-export function submenuForRuns(createWindow: CreateWindowFunction, runs: string[]): MenuItemConstructorOptions[] {
+export function runMenuItems(createWindow: CreateWindowFunction, runs: string[]): MenuItemConstructorOptions[] {
   return runs.map((run) => ({ label: run, click: () => openRun(run, createWindow) }))
+}
+
+export default async function submenuForRuns(
+  createWindow: CreateWindowFunction
+): Promise<MenuItemConstructorOptions[]> {
+  const runs = await readRunsDir()
+
+  return [
+    { label: "Recent Runs", enabled: false },
+    ...(runs.length && runs[0] !== RUNS_ERROR ? runMenuItems(createWindow, runs) : [{ label: RUNS_ERROR }]),
+  ]
 }


### PR DESCRIPTION
This PR flattens the list of profiles into the top-level menu, and the list of runs for a profile into that profile's menu. It also adds a missing copyright header to tray/menus/runs.ts