### PR TITLE
feat: some minor cleanups to the tray profiles menu layout and source

### DIFF
--- a/plugins/plugin-codeflare/src/tray/menus/profiles/boot.ts
+++ b/plugins/plugin-codeflare/src/tray/menus/profiles/boot.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CreateWindowFunction } from "@kui-shell/core"
+
+import { bootIcon } from "../../icons"
+import windowOptions from "../../window"
+
+/** Handler for booting up a profile */
+async function boot(profile: string, createWindow: CreateWindowFunction) {
+  createWindow(
+    ["codeflare", "gui", "guide", "ml/ray/start/kubernetes", "--profile", profile],
+    windowOptions({ title: "Booting " + profile })
+  )
+}
+
+export default function bootMenuItem(profile: string, createWindow: CreateWindowFunction) {
+  return { label: "Boot", icon: bootIcon, click: () => boot(profile, createWindow) }
+}

--- a/plugins/plugin-codeflare/src/tray/menus/profiles/index.ts
+++ b/plugins/plugin-codeflare/src/tray/menus/profiles/index.ts
@@ -18,28 +18,14 @@ import { Choices, Profiles } from "madwizard"
 import { MenuItemConstructorOptions } from "electron"
 import { CreateWindowFunction } from "@kui-shell/core"
 
-import UpdateFunction from "../update"
-import windowOptions from "../window"
-import { profileIcon, bootIcon, shutDownIcon } from "../icons"
+import boot from "./boot"
+import shutdown from "./shutdown"
 import submenuForRuns from "./runs"
 
-import ProfileStatusWatcher from "../watchers/profile/status"
+import UpdateFunction from "../../update"
+import { profileIcon } from "../../icons"
 
-/** Handler for booting up a profile */
-async function boot(profile: string, createWindow: CreateWindowFunction) {
-  createWindow(
-    ["codeflare", "gui", "guide", "ml/ray/start/kubernetes", "--profile", profile],
-    windowOptions({ title: "Booting " + profile })
-  )
-}
-
-/** Handler for shutting down a profile */
-async function shutdown(profile: string, createWindow: CreateWindowFunction) {
-  createWindow(
-    ["codeflare", "gui", "guide", "ml/ray/stop/kubernetes", "--profile", profile],
-    windowOptions({ title: "Shutting down " + profile })
-  )
-}
+import ProfileStatusWatcher from "../../watchers/profile/status"
 
 const watchers: Record<string, ProfileStatusWatcher> = {}
 
@@ -58,11 +44,12 @@ async function submenuForOneProfile(
     label: state.profile.name,
     icon: profileIcon,
     submenu: [
+      boot(state.profile.name, createWindow),
+      shutdown(state.profile.name, createWindow),
+      { type: "separator" },
+      { label: "Status", enabled: false },
       watcher.head,
       watcher.workers,
-      { type: "separator" },
-      { label: "Boot", icon: bootIcon, click: () => boot(state.profile.name, createWindow) },
-      { label: "Shutdown", icon: shutDownIcon, click: () => shutdown(state.profile.name, createWindow) },
       { type: "separator" },
       ...(await submenuForRuns(createWindow)),
     ],

--- a/plugins/plugin-codeflare/src/tray/menus/profiles/runs.ts
+++ b/plugins/plugin-codeflare/src/tray/menus/profiles/runs.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { MenuItemConstructorOptions } from "electron"
-import { Profiles } from "madwizard"
-import { CreateWindowFunction } from "@kui-shell/core"
-import { readdir } from "fs/promises"
 import { join } from "path"
+import { readdir } from "fs/promises"
+import { Profiles } from "madwizard"
+import { MenuItemConstructorOptions } from "electron"
+import { CreateWindowFunction } from "@kui-shell/core"
 
-import windowOptions from "../window"
+import windowOptions from "../../window"
 
 export const RUNS_ERROR = "No runs found"
 

--- a/plugins/plugin-codeflare/src/tray/menus/profiles/shutdown.ts
+++ b/plugins/plugin-codeflare/src/tray/menus/profiles/shutdown.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CreateWindowFunction } from "@kui-shell/core"
+
+import windowOptions from "../../window"
+import { shutDownIcon } from "../../icons"
+
+/** Handler for shutting down a profile */
+async function shutdown(profile: string, createWindow: CreateWindowFunction) {
+  createWindow(
+    ["codeflare", "gui", "guide", "ml/ray/stop/kubernetes", "--profile", profile],
+    windowOptions({ title: "Shutting down " + profile })
+  )
+}
+
+export default function shutdownMenuItem(profile: string, createWindow: CreateWindowFunction) {
+  return { label: "Shutdown", icon: shutDownIcon, click: () => shutdown(profile, createWindow) }
+}


### PR DESCRIPTION
- place boot and shutdown at the top
- add a Status "header" to the Head x/y Worker x/y section

<img width="561" alt="codeflare tray menu v7" src="https://user-images.githubusercontent.com/4741620/180332986-a33caa45-5766-4eea-a445-670424ec27fa.png">

