### PR TITLE
fix: tray-launched subprocesses have no HOME

### DIFF
--- a/plugins/plugin-codeflare/src/controller/respawn.ts
+++ b/plugins/plugin-codeflare/src/controller/respawn.ts
@@ -32,6 +32,7 @@ export default function respawnCommand(cmdline: string | string[]) {
       ELECTRON_RUN_AS_NODE: "true",
       GUIDEBOOK_STORE: process.env.GUIDEBOOK_STORE || "",
       DEBUG: process.env.DEBUG || "",
+      HOME: process.env.HOME || "",
       PATH: process.env.PATH || "",
       KUBECONFIG: process.env.KUBECONFIG || "",
     },


### PR DESCRIPTION
this can result in random files (such as .kube/cache) appearing in your CWD