### PR TITLE
feat: add Dashboard tray menu, with MLFlow entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,23 +11,23 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@kui-shell/client": "file:./plugins/plugin-client-default",
-        "@kui-shell/core": "11.5.0-dev-20220718-153910",
-        "@kui-shell/plugin-bash-like": "11.5.0-dev-20220718-153910",
-        "@kui-shell/plugin-client-common": "11.5.0-dev-20220718-153910",
+        "@kui-shell/core": "11.5.0-dev-20220722-172700",
+        "@kui-shell/plugin-bash-like": "11.5.0-dev-20220722-172700",
+        "@kui-shell/plugin-client-common": "11.5.0-dev-20220722-172700",
         "@kui-shell/plugin-codeflare": "file:./plugins/plugin-codeflare",
-        "@kui-shell/plugin-core-support": "11.5.0-dev-20220718-153910",
-        "@kui-shell/plugin-electron-components": "11.5.0-dev-20220718-153910",
-        "@kui-shell/plugin-kubectl": "11.5.0-dev-20220718-153910",
+        "@kui-shell/plugin-core-support": "11.5.0-dev-20220722-172700",
+        "@kui-shell/plugin-electron-components": "11.5.0-dev-20220722-172700",
+        "@kui-shell/plugin-kubectl": "11.5.0-dev-20220722-172700",
         "@kui-shell/plugin-madwizard": "file:./plugins/plugin-madwizard",
-        "@kui-shell/plugin-patternfly4-themes": "11.5.0-dev-20220718-153910",
-        "@kui-shell/plugin-proxy-support": "11.5.0-dev-20220718-153910",
-        "@kui-shell/plugin-s3": "11.5.0-dev-20220718-153910"
+        "@kui-shell/plugin-patternfly4-themes": "11.5.0-dev-20220722-172700",
+        "@kui-shell/plugin-proxy-support": "11.5.0-dev-20220722-172700",
+        "@kui-shell/plugin-s3": "11.5.0-dev-20220722-172700"
       },
       "devDependencies": {
-        "@kui-shell/builder": "11.5.0-dev-20220718-153910",
-        "@kui-shell/proxy": "11.5.0-dev-20220718-153910",
-        "@kui-shell/react": "11.5.0-dev-20220718-153910",
-        "@kui-shell/webpack": "11.5.0-dev-20220718-153910",
+        "@kui-shell/builder": "11.5.0-dev-20220722-172700",
+        "@kui-shell/proxy": "11.5.0-dev-20220722-172700",
+        "@kui-shell/react": "11.5.0-dev-20220722-172700",
+        "@kui-shell/webpack": "11.5.0-dev-20220722-172700",
         "@playwright/test": "^1.23.2",
         "@types/debug": "^4.1.7",
         "@types/node": "14.11.8",
@@ -610,9 +610,9 @@
       }
     },
     "node_modules/@kui-shell/builder": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/builder/-/builder-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-GrxMs/okGsqeW2jtd0gDxBE0R+rupjX71LPbZHsUZoLS9xMwaJgEDD4xj/cr/RQNG/iN/mEvUgcvIBUFVPUxwQ==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/builder/-/builder-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-poQY57LXKTuzGRP9KL05Zbxiik3tpeWtKrwH2iLlh1p847kGQSIp8SfvlGOEBakerwcYwFOLnrQmI+OL6D+nbw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -639,9 +639,9 @@
       "link": true
     },
     "node_modules/@kui-shell/core": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/core/-/core-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-5PWECMXPnwsJJ4/5fBZJE9CgOwpHSY/WcFOYvOdlcnaGW/UL7YManaMKDSlf5zMv5I4sOM8+uF7B7w5UJFq3NQ==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/core/-/core-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-wXlNuJ5Ayj3mvJCfmvuaEjh4/NnSuxGPml5ZZ25pnrfue4EgVLTHd590xp4CaHhqAz07DX1KfGvP3dEdOQq89g==",
       "dependencies": {
         "@electron/remote": "2.0.8",
         "ansi-to-html": "0.7.2",
@@ -674,9 +674,9 @@
       }
     },
     "node_modules/@kui-shell/plugin-bash-like": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-bash-like/-/plugin-bash-like-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-C1mcOixNES+LcgyeYYJaB6pu7FNJKYQsnEvIXnvHsWNcCRbWZ5/IpzDl1+aUTCJc800f3GAiYlPhcnVaba9dmg==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-bash-like/-/plugin-bash-like-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-CFccpIQ1Y9gGoLe9zpfHGEfDgbNPzVxe1FADC4kPUpjN0BEQ/g5RR1gItMz0ndhdqdOOvjZpTH/RZ2r51MEYHw==",
       "dependencies": {
         "@kui-shell/xterm-helpers": "1.0.2",
         "cookie": "0.4.2",
@@ -694,9 +694,9 @@
       }
     },
     "node_modules/@kui-shell/plugin-client-common": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-client-common/-/plugin-client-common-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-VXBbRjhR491Uiq7cA+V3VIwEhoKl5mSJM8RPOGydgOGj49FIxdemlPlkiPGd0Egz7yiPBWoozpoY60/TVyLsag==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-client-common/-/plugin-client-common-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-cYdJt0tKDNGk73Y16ZvYId2ju45QFGqHzysXDD9UO2X1lh40+3gc13SX+L36ecT68+kjSDhd3+w+QwDCu3p1xw==",
       "dependencies": {
         "@fortawesome/fontawesome-free": "6.1.1",
         "@mdi/font": "6.9.96",
@@ -732,9 +732,9 @@
       "link": true
     },
     "node_modules/@kui-shell/plugin-core-support": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-core-support/-/plugin-core-support-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-yZiS8tFuISKwF2tBqAIPAzkbMHJRiedeRL5IqMB6339xIysJqpMRG5haye4romQ9HTGC+j7mbRoPcF6e2IpkRg==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-core-support/-/plugin-core-support-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-iYG3GI8N3HAxiOPWp3kW5ecD37HTYcgb4QnlPjHx2NIsnFm9wIXYRGtFvoU61QfV+oNDxhxoabUEr7emQkWylg==",
       "dependencies": {
         "@electron/remote": "2.0.8",
         "@supercharge/promise-pool": "2.1.0",
@@ -743,17 +743,17 @@
       }
     },
     "node_modules/@kui-shell/plugin-electron-components": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-electron-components/-/plugin-electron-components-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-qNCqXylacn3317AMZW2PjEWHWSI6QScMCDslSNjAJWTf6lHKIgSnJpuSXIHy/xZtJt64jt7ZmczOB2/4DhPVlw==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-electron-components/-/plugin-electron-components-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-ECQEcByZf1aFALPjKProhvz0GmOXXIW4Jjlc/pAaBg430S+bdkAD+jwZRbXN1VACStc6VZAjagO/3in3mf1TAg==",
       "dependencies": {
         "@electron/remote": "2.0.8"
       }
     },
     "node_modules/@kui-shell/plugin-kubectl": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl/-/plugin-kubectl-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-1uNjCXmslzDv1tlecR2OmulB0XpZqPKpzMThFLMe+VhWuHdTBLCjlCgh+A1pk1RGPnVCKquP5qvUexuRoNz+9g==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl/-/plugin-kubectl-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-h9ucxByqFg0fwNT+GFKx0sFRRXy4v3MqMmL7P44xYqnbaQqifUTBiEm4BrpRY25OLL6cChwJ7f+zg3S+4Iq1Rg==",
       "dependencies": {
         "@kui-shell/jsonpath": "1.1.1",
         "bytes-iec": "3.1.1",
@@ -797,19 +797,19 @@
       "link": true
     },
     "node_modules/@kui-shell/plugin-patternfly4-themes": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-patternfly4-themes/-/plugin-patternfly4-themes-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-XBb4HOg2IetgBBL/kppc+aHd5WgRk5CE9UsAqzs2zTUjJspM+FM2mCek6aLaxl05sSczZb+2/v/mI3p0aD31JA=="
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-patternfly4-themes/-/plugin-patternfly4-themes-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-4Vl6zfvJdcACxY9Ct9ygLIczEi4cC5uAr7XShdhBwWWK9usEVMoJ331S99EiZvjtE4/fSzkfO2hgSa/YNHv39w=="
     },
     "node_modules/@kui-shell/plugin-proxy-support": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-proxy-support/-/plugin-proxy-support-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-GCwWF/ZJ5cgjMhmowOWtUn1XVlUZBWVaHY3rMeAhiC0lA0Jo5SLgKMug4ux5KVVcki9GvoAtVYfpgqgAyYKgKw=="
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-proxy-support/-/plugin-proxy-support-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-k002aCpon55k47ds/YBFWHjfnTv6Uiaht7NRrhQuIUf8Os6EPRlWQIrHnGvWIzUZQHtGvwVITOaQqHKdr+vBgQ=="
     },
     "node_modules/@kui-shell/plugin-s3": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-s3/-/plugin-s3-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-5Mno2qavXsYa5wVVLfQ+7ae4lJeAQSbK9I19x39cozp3Y6DjgGnVbkEih3y+6r1ncf/5MPa2Ww4XTnC/c02bmA==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-s3/-/plugin-s3-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-0gGUra5u9ZFKQdgk4gDF5qKyRl7T6QLopUZOALDEcyL9kJ7THkB38JlIFguOA2b5QgBzb2aK0lmsStNN07J/7g==",
       "dependencies": {
         "common-path-prefix": "3.0.0",
         "ini": "2.0.0",
@@ -818,9 +818,9 @@
       }
     },
     "node_modules/@kui-shell/proxy": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/proxy/-/proxy-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-SQw/fvCJQp6vt8M9O8w6tAoZKNQsRN/6EhiKoDscvdCrSu8XiyQ8EGGj2cYeA5xpQ6HoMJO79R6Uabkt5gJ8TQ==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/proxy/-/proxy-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-AsdrmZMeTy2jPwH3HkcItwfHq5CR+OYvqJi54eWD/bodrwC53v3W7gV3Sd9IAUGcaheAB8TO1dILjAEJMSUh1Q==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -831,9 +831,9 @@
       }
     },
     "node_modules/@kui-shell/react": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/react/-/react-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-BsYoKPmQUW0z1Ii/AWQD0rqNdahN/74GB/3g3zujfKmlkrlLgQb7RF8fh/D1c1av3o2pQjx7SUoxUHPhPk3bnQ==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/react/-/react-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-5MC6Vg1Oj2pTHzoUIQWEPzC/4iTyTvQLSZTURQQYDeLxHXjNdLQzwIVrl6wDQMetLtjV/wmReE+hiFW/xPA3Fg==",
       "dev": true,
       "dependencies": {
         "react": "17.0.2",
@@ -841,9 +841,9 @@
       }
     },
     "node_modules/@kui-shell/webpack": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/webpack/-/webpack-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-MU5iJS0B5Ye6qSdOb2qOuHNyoSyOsLbXpZvj3KPIIkxj4lrKfjgewBUs7HG0gczAuDm1DpWEv8rpGEFjK2w2og==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/webpack/-/webpack-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-6GM7ZvjGxqCOEzZvKaAbnsJbpbvb0vDT6hZV7auUArXM4lBsPv9tl2XCvkFKLKPWPOJKROg1GyzJNCvtHkDsgg==",
       "dev": true,
       "dependencies": {
         "assert": "2.0.0",
@@ -14274,9 +14274,9 @@
       }
     },
     "@kui-shell/builder": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/builder/-/builder-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-GrxMs/okGsqeW2jtd0gDxBE0R+rupjX71LPbZHsUZoLS9xMwaJgEDD4xj/cr/RQNG/iN/mEvUgcvIBUFVPUxwQ==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/builder/-/builder-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-poQY57LXKTuzGRP9KL05Zbxiik3tpeWtKrwH2iLlh1p847kGQSIp8SfvlGOEBakerwcYwFOLnrQmI+OL6D+nbw==",
       "dev": true,
       "requires": {
         "@babel/cli": "7.18.6",
@@ -14291,9 +14291,9 @@
       "version": "file:plugins/plugin-client-default"
     },
     "@kui-shell/core": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/core/-/core-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-5PWECMXPnwsJJ4/5fBZJE9CgOwpHSY/WcFOYvOdlcnaGW/UL7YManaMKDSlf5zMv5I4sOM8+uF7B7w5UJFq3NQ==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/core/-/core-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-wXlNuJ5Ayj3mvJCfmvuaEjh4/NnSuxGPml5ZZ25pnrfue4EgVLTHd590xp4CaHhqAz07DX1KfGvP3dEdOQq89g==",
       "requires": {
         "@electron/remote": "2.0.8",
         "ansi-to-html": "0.7.2",
@@ -14322,9 +14322,9 @@
       }
     },
     "@kui-shell/plugin-bash-like": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-bash-like/-/plugin-bash-like-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-C1mcOixNES+LcgyeYYJaB6pu7FNJKYQsnEvIXnvHsWNcCRbWZ5/IpzDl1+aUTCJc800f3GAiYlPhcnVaba9dmg==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-bash-like/-/plugin-bash-like-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-CFccpIQ1Y9gGoLe9zpfHGEfDgbNPzVxe1FADC4kPUpjN0BEQ/g5RR1gItMz0ndhdqdOOvjZpTH/RZ2r51MEYHw==",
       "requires": {
         "@kui-shell/xterm-helpers": "1.0.2",
         "cookie": "0.4.2",
@@ -14342,9 +14342,9 @@
       }
     },
     "@kui-shell/plugin-client-common": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-client-common/-/plugin-client-common-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-VXBbRjhR491Uiq7cA+V3VIwEhoKl5mSJM8RPOGydgOGj49FIxdemlPlkiPGd0Egz7yiPBWoozpoY60/TVyLsag==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-client-common/-/plugin-client-common-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-cYdJt0tKDNGk73Y16ZvYId2ju45QFGqHzysXDD9UO2X1lh40+3gc13SX+L36ecT68+kjSDhd3+w+QwDCu3p1xw==",
       "requires": {
         "@fortawesome/fontawesome-free": "6.1.1",
         "@mdi/font": "6.9.96",
@@ -14398,9 +14398,9 @@
       }
     },
     "@kui-shell/plugin-core-support": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-core-support/-/plugin-core-support-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-yZiS8tFuISKwF2tBqAIPAzkbMHJRiedeRL5IqMB6339xIysJqpMRG5haye4romQ9HTGC+j7mbRoPcF6e2IpkRg==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-core-support/-/plugin-core-support-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-iYG3GI8N3HAxiOPWp3kW5ecD37HTYcgb4QnlPjHx2NIsnFm9wIXYRGtFvoU61QfV+oNDxhxoabUEr7emQkWylg==",
       "requires": {
         "@electron/remote": "2.0.8",
         "@supercharge/promise-pool": "2.1.0",
@@ -14409,17 +14409,17 @@
       }
     },
     "@kui-shell/plugin-electron-components": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-electron-components/-/plugin-electron-components-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-qNCqXylacn3317AMZW2PjEWHWSI6QScMCDslSNjAJWTf6lHKIgSnJpuSXIHy/xZtJt64jt7ZmczOB2/4DhPVlw==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-electron-components/-/plugin-electron-components-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-ECQEcByZf1aFALPjKProhvz0GmOXXIW4Jjlc/pAaBg430S+bdkAD+jwZRbXN1VACStc6VZAjagO/3in3mf1TAg==",
       "requires": {
         "@electron/remote": "2.0.8"
       }
     },
     "@kui-shell/plugin-kubectl": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl/-/plugin-kubectl-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-1uNjCXmslzDv1tlecR2OmulB0XpZqPKpzMThFLMe+VhWuHdTBLCjlCgh+A1pk1RGPnVCKquP5qvUexuRoNz+9g==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl/-/plugin-kubectl-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-h9ucxByqFg0fwNT+GFKx0sFRRXy4v3MqMmL7P44xYqnbaQqifUTBiEm4BrpRY25OLL6cChwJ7f+zg3S+4Iq1Rg==",
       "requires": {
         "@kui-shell/jsonpath": "1.1.1",
         "bytes-iec": "3.1.1",
@@ -14456,19 +14456,19 @@
       }
     },
     "@kui-shell/plugin-patternfly4-themes": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-patternfly4-themes/-/plugin-patternfly4-themes-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-XBb4HOg2IetgBBL/kppc+aHd5WgRk5CE9UsAqzs2zTUjJspM+FM2mCek6aLaxl05sSczZb+2/v/mI3p0aD31JA=="
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-patternfly4-themes/-/plugin-patternfly4-themes-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-4Vl6zfvJdcACxY9Ct9ygLIczEi4cC5uAr7XShdhBwWWK9usEVMoJ331S99EiZvjtE4/fSzkfO2hgSa/YNHv39w=="
     },
     "@kui-shell/plugin-proxy-support": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-proxy-support/-/plugin-proxy-support-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-GCwWF/ZJ5cgjMhmowOWtUn1XVlUZBWVaHY3rMeAhiC0lA0Jo5SLgKMug4ux5KVVcki9GvoAtVYfpgqgAyYKgKw=="
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-proxy-support/-/plugin-proxy-support-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-k002aCpon55k47ds/YBFWHjfnTv6Uiaht7NRrhQuIUf8Os6EPRlWQIrHnGvWIzUZQHtGvwVITOaQqHKdr+vBgQ=="
     },
     "@kui-shell/plugin-s3": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-s3/-/plugin-s3-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-5Mno2qavXsYa5wVVLfQ+7ae4lJeAQSbK9I19x39cozp3Y6DjgGnVbkEih3y+6r1ncf/5MPa2Ww4XTnC/c02bmA==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-s3/-/plugin-s3-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-0gGUra5u9ZFKQdgk4gDF5qKyRl7T6QLopUZOALDEcyL9kJ7THkB38JlIFguOA2b5QgBzb2aK0lmsStNN07J/7g==",
       "requires": {
         "common-path-prefix": "3.0.0",
         "ini": "2.0.0",
@@ -14477,15 +14477,15 @@
       }
     },
     "@kui-shell/proxy": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/proxy/-/proxy-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-SQw/fvCJQp6vt8M9O8w6tAoZKNQsRN/6EhiKoDscvdCrSu8XiyQ8EGGj2cYeA5xpQ6HoMJO79R6Uabkt5gJ8TQ==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/proxy/-/proxy-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-AsdrmZMeTy2jPwH3HkcItwfHq5CR+OYvqJi54eWD/bodrwC53v3W7gV3Sd9IAUGcaheAB8TO1dILjAEJMSUh1Q==",
       "dev": true
     },
     "@kui-shell/react": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/react/-/react-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-BsYoKPmQUW0z1Ii/AWQD0rqNdahN/74GB/3g3zujfKmlkrlLgQb7RF8fh/D1c1av3o2pQjx7SUoxUHPhPk3bnQ==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/react/-/react-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-5MC6Vg1Oj2pTHzoUIQWEPzC/4iTyTvQLSZTURQQYDeLxHXjNdLQzwIVrl6wDQMetLtjV/wmReE+hiFW/xPA3Fg==",
       "dev": true,
       "requires": {
         "react": "17.0.2",
@@ -14493,9 +14493,9 @@
       }
     },
     "@kui-shell/webpack": {
-      "version": "11.5.0-dev-20220718-153910",
-      "resolved": "https://registry.npmjs.org/@kui-shell/webpack/-/webpack-11.5.0-dev-20220718-153910.tgz",
-      "integrity": "sha512-MU5iJS0B5Ye6qSdOb2qOuHNyoSyOsLbXpZvj3KPIIkxj4lrKfjgewBUs7HG0gczAuDm1DpWEv8rpGEFjK2w2og==",
+      "version": "11.5.0-dev-20220722-172700",
+      "resolved": "https://registry.npmjs.org/@kui-shell/webpack/-/webpack-11.5.0-dev-20220722-172700.tgz",
+      "integrity": "sha512-6GM7ZvjGxqCOEzZvKaAbnsJbpbvb0vDT6hZV7auUArXM4lBsPv9tl2XCvkFKLKPWPOJKROg1GyzJNCvtHkDsgg==",
       "dev": true,
       "requires": {
         "assert": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -86,10 +86,10 @@
     "printWidth": 120
   },
   "devDependencies": {
-    "@kui-shell/builder": "11.5.0-dev-20220718-153910",
-    "@kui-shell/proxy": "11.5.0-dev-20220718-153910",
-    "@kui-shell/react": "11.5.0-dev-20220718-153910",
-    "@kui-shell/webpack": "11.5.0-dev-20220718-153910",
+    "@kui-shell/builder": "11.5.0-dev-20220722-172700",
+    "@kui-shell/proxy": "11.5.0-dev-20220722-172700",
+    "@kui-shell/react": "11.5.0-dev-20220722-172700",
+    "@kui-shell/webpack": "11.5.0-dev-20220722-172700",
     "@playwright/test": "^1.23.2",
     "@types/debug": "^4.1.7",
     "@types/node": "14.11.8",
@@ -113,16 +113,16 @@
   },
   "dependencies": {
     "@kui-shell/client": "file:./plugins/plugin-client-default",
-    "@kui-shell/core": "11.5.0-dev-20220718-153910",
-    "@kui-shell/plugin-bash-like": "11.5.0-dev-20220718-153910",
-    "@kui-shell/plugin-client-common": "11.5.0-dev-20220718-153910",
+    "@kui-shell/core": "11.5.0-dev-20220722-172700",
+    "@kui-shell/plugin-bash-like": "11.5.0-dev-20220722-172700",
+    "@kui-shell/plugin-client-common": "11.5.0-dev-20220722-172700",
     "@kui-shell/plugin-codeflare": "file:./plugins/plugin-codeflare",
-    "@kui-shell/plugin-core-support": "11.5.0-dev-20220718-153910",
-    "@kui-shell/plugin-electron-components": "11.5.0-dev-20220718-153910",
-    "@kui-shell/plugin-kubectl": "11.5.0-dev-20220718-153910",
+    "@kui-shell/plugin-core-support": "11.5.0-dev-20220722-172700",
+    "@kui-shell/plugin-electron-components": "11.5.0-dev-20220722-172700",
+    "@kui-shell/plugin-kubectl": "11.5.0-dev-20220722-172700",
     "@kui-shell/plugin-madwizard": "file:./plugins/plugin-madwizard",
-    "@kui-shell/plugin-patternfly4-themes": "11.5.0-dev-20220718-153910",
-    "@kui-shell/plugin-proxy-support": "11.5.0-dev-20220718-153910",
-    "@kui-shell/plugin-s3": "11.5.0-dev-20220718-153910"
+    "@kui-shell/plugin-patternfly4-themes": "11.5.0-dev-20220722-172700",
+    "@kui-shell/plugin-proxy-support": "11.5.0-dev-20220722-172700",
+    "@kui-shell/plugin-s3": "11.5.0-dev-20220722-172700"
   }
 }

--- a/plugins/plugin-codeflare/src/controller/index.ts
+++ b/plugins/plugin-codeflare/src/controller/index.ts
@@ -42,8 +42,8 @@ export default function registerCodeflareCommands(registrar: Registrar) {
   registrar.listen("/help", help)
 
   registrar.listen("/codeflare/version", () => import("@kui-shell/client/package.json").then((_) => _.version))
-
   registrar.listen("/codeflare/gui/guide", (args) => import("./guide").then((_) => _.default(args)), {
+    needsUI: true,
     width: 1280,
     height: 800,
   })

--- a/plugins/plugin-codeflare/src/tray/menus/profiles/dashboards/index.ts
+++ b/plugins/plugin-codeflare/src/tray/menus/profiles/dashboards/index.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MenuItemConstructorOptions } from "electron"
+import { CreateWindowFunction } from "@kui-shell/core"
+
+/** @return menu items that open dashboards for the given `profile` */
+export default function dashboards(profile: string, createWindow: CreateWindowFunction): MenuItemConstructorOptions[] {
+  return [{ label: "MLFlow", click: () => import("./mlflow").then((_) => _.default(profile, createWindow)) }]
+}

--- a/plugins/plugin-codeflare/src/tray/menus/profiles/dashboards/mlflow.ts
+++ b/plugins/plugin-codeflare/src/tray/menus/profiles/dashboards/mlflow.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cli } from "madwizard/dist/fe/cli"
+import { CreateWindowFunction } from "@kui-shell/core"
+
+import windowOptions from "../../../window"
+
+export default async function openMLFlow(profile: string, createWindow: CreateWindowFunction) {
+  const guidebook = "ml/ray/start/kubernetes/port-forward/mlflow"
+
+  const resp = await cli(["madwizard", "guide", guidebook], undefined, {
+    clean: false /* don't kill the port-forward subprocess! we'll manage that */,
+    interactive: false,
+    store: process.env.GUIDEBOOK_STORE,
+  })
+
+  if (resp) {
+    if (!resp.env.MLFLOW_PORT) {
+      console.error("Unable to open MLFlow, due to an error in connecting to the remote server")
+    } else {
+      // the `createWindow` api returns a promise that will resolve
+      // when the window closes
+      await createWindow(
+        "http://localhost:" + resp.env.MLFLOW_PORT,
+        windowOptions({ title: "MLFlow Dashboard " + profile }) // might not matter, as MLFlow's web page has its own title
+      )
+
+      // now the window has closed, so we can clean up any
+      // subprocesses spawned by the guidebook
+      if (typeof resp.cleanExit === "function") {
+        resp.cleanExit()
+      }
+    }
+  }
+}

--- a/plugins/plugin-codeflare/src/tray/menus/profiles/runs.ts
+++ b/plugins/plugin-codeflare/src/tray/menus/profiles/runs.ts
@@ -61,8 +61,5 @@ export default async function submenuForRuns(
 ): Promise<MenuItemConstructorOptions[]> {
   const runs = await readRunsDir(profile)
 
-  return [
-    { label: "Recent Runs", enabled: false },
-    ...(runs.length && runs[0] !== RUNS_ERROR ? runMenuItems(profile, createWindow, runs) : [{ label: RUNS_ERROR }]),
-  ]
+  return runs.length && runs[0] !== RUNS_ERROR ? runMenuItems(profile, createWindow, runs) : [{ label: RUNS_ERROR }]
 }

--- a/plugins/plugin-codeflare/src/tray/menus/section.ts
+++ b/plugins/plugin-codeflare/src/tray/menus/section.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MenuItemConstructorOptions } from "electron"
+
+/**
+ * @return the given list of menu `items`, with a prepended "header"
+ * item that has the given `label`. If `separator` is true, an additional
+ * initial separator menu item will be prepended to the returned list.
+ *
+ */
+export default function section(
+  label: string,
+  items: MenuItemConstructorOptions[],
+  separator = false
+): MenuItemConstructorOptions[] {
+  return [
+    ...(separator ? [{ type: "separator" as const }] : []),
+    { label, enabled: false }, // at least on macOS, this gives a nice header-like appearance
+    ...items,
+  ]
+}


### PR DESCRIPTION
This menu item uses the ml/ray/start/kubernetes/port-forward/mlflow guidebook to set up a port forward to the mlflow service started by the codeflare ray helm chart. It opens a kui window to localhost:thatPort, and then tears down the port-forward when the user closes that popup window.