### PR TITLE
feat: expose `-p/--profile` option to start a run with a desired profile

### DIFF
--- a/bin/codeflare
+++ b/bin/codeflare
@@ -111,7 +111,7 @@ fi
 # indicated by the -u option)
 do_cli=1
 use_docker=0
-while getopts "iqaydnVus:" opt
+while getopts "piqaydnVus:" opt
 do
     case $opt in
         d) use_docker=1; continue;;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7494,9 +7494,9 @@
       }
     },
     "node_modules/madwizard": {
-      "version": "0.15.6",
-      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.15.6.tgz",
-      "integrity": "sha512-UgaEUSzJwudRRukWsrZTc/7CAQwTVxb7v+42W77SgUBBeyjpcsbXHk4ARLnSQDpr/AH5TPfWDWg+qBAaHuDNoQ==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.15.7.tgz",
+      "integrity": "sha512-H5M/rStYGdZ8hDXOzq2tVQ4HKkBdZhOIont+4TuXnAWwN0EA1aoCOLo27hRRy3J1f4IkdKSxsNXqMmbJopE0/g==",
       "dependencies": {
         "chalk": "^5.0.1",
         "cli-highlight": "^2.1.11",
@@ -13903,7 +13903,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "madwizard": "^0.15.6"
+        "madwizard": "^0.15.7"
       }
     }
   },
@@ -14452,7 +14452,7 @@
     "@kui-shell/plugin-madwizard": {
       "version": "file:plugins/plugin-madwizard",
       "requires": {
-        "madwizard": "^0.15.6"
+        "madwizard": "^0.15.7"
       }
     },
     "@kui-shell/plugin-patternfly4-themes": {
@@ -18695,9 +18695,9 @@
       "integrity": "sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ=="
     },
     "madwizard": {
-      "version": "0.15.6",
-      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.15.6.tgz",
-      "integrity": "sha512-UgaEUSzJwudRRukWsrZTc/7CAQwTVxb7v+42W77SgUBBeyjpcsbXHk4ARLnSQDpr/AH5TPfWDWg+qBAaHuDNoQ==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.15.7.tgz",
+      "integrity": "sha512-H5M/rStYGdZ8hDXOzq2tVQ4HKkBdZhOIont+4TuXnAWwN0EA1aoCOLo27hRRy3J1f4IkdKSxsNXqMmbJopE0/g==",
       "requires": {
         "chalk": "^5.0.1",
         "cli-highlight": "^2.1.11",

--- a/plugins/plugin-madwizard/package.json
+++ b/plugins/plugin-madwizard/package.json
@@ -23,6 +23,6 @@
     "access": "public"
   },
   "dependencies": {
-    "madwizard": "^0.15.6"
+    "madwizard": "^0.15.7"
   }
 }

--- a/plugins/plugin-madwizard/src/plugin.ts
+++ b/plugins/plugin-madwizard/src/plugin.ts
@@ -23,19 +23,34 @@ export interface Options extends ParsedOptions {
   /** verbose output */
   V: boolean
 
+  /** verbose output */
+  verbose: boolean
+
   /** do not load prior choices (the default "profile") */
   n: boolean
 
+  /** Use this named profile */
+  p: string
+
+  /** Use this named profile */
+  profile: string
+
   /** Do not tee logs to the console */
   q: boolean
+
+  /** Do not tee logs to the console */
   quiet: boolean
 
   /** Automatically accept all choices from the current profile */
   y: boolean
+
+  /** Automatically accept all choices from the current profile */
   yes: boolean
 
   /** Interactive guide mode? [default: false] */
   i: boolean
+
+  /** Interactive guide mode? [default: false] */
   interactive: boolean
 }
 
@@ -74,6 +89,7 @@ export function doMadwizard(
         {
           store: parsedOptions.s || process.env.GUIDEBOOK_STORE,
           verbose: parsedOptions.V,
+          profile: parsedOptions.p,
           interactive: parsedOptions.i || !parsedOptions.y,
         }
       )
@@ -99,7 +115,7 @@ export function doMadwizard(
 export default function registerMadwizardCommands(registrar: Registrar) {
   const flags = {
     boolean: ["u", "V", "n", "q", "i", "y"],
-    alias: { quiet: ["q"], interactive: ["i"], yes: ["y"] },
+    alias: { quiet: ["q"], interactive: ["i"], yes: ["y"], profile: ["p"], verbose: ["V"] },
   }
 
   registrar.listen("/profile", doMadwizard(true, "profile"))


### PR DESCRIPTION
Also: bump to madwizard 0.15.7 to pick up profile fix
codeflare -p myprofile, the desired myprofile was not used in all cases by madwizard in its subprocess executions