### PR TITLE
fix: tray dashboard popups should be in follow mode

### DIFF
--- a/plugins/plugin-codeflare/src/tray/menus/profiles/dashboards/codeflare.ts
+++ b/plugins/plugin-codeflare/src/tray/menus/profiles/dashboards/codeflare.ts
@@ -27,7 +27,9 @@ import windowOptions from "../../../window"
 function openRunInCodeflareDashboard(createWindow: CreateWindowFunction, profile: string, runId: string) {
   const runsDir = Profiles.guidebookJobDataPath({ profile })
   createWindow(
-    ["codeflare", "dashboard", join(runsDir, runId)],
+    // TODO -f: follow by default. should we be smarter, and detect
+    // which -runs are in a non-RUNNING state, and don't follow those?
+    ["codeflare", "dashboard", "-f", join(runsDir, runId)],
     windowOptions({ title: "CodeFlare Dashboard - " + runId })
   )
 }


### PR DESCRIPTION
for now, at least. it would be nice if we could detect whether a job is running, and only follow running jobs... until we have that kind of capability, we need to follow everything...