### PR TITLE
fix: tray runs watch still adds garbage, and does not respond to deletion

### DIFF
--- a/plugins/plugin-codeflare/src/tray/watchers/profile/list.ts
+++ b/plugins/plugin-codeflare/src/tray/watchers/profile/list.ts
@@ -31,7 +31,7 @@ export default class ProfileWatcher {
   public constructor(
     private readonly updateFn: UpdateFunction,
     private readonly profilesPath: string,
-    private readonly watcher = chokidar.watch(profilesPath, { depth: 0 })
+    private readonly watcher = chokidar.watch(profilesPath, { depth: 1 })
   ) {}
 
   /** Initialize `this._profiles` model */

--- a/plugins/plugin-codeflare/src/tray/watchers/profile/run.ts
+++ b/plugins/plugin-codeflare/src/tray/watchers/profile/run.ts
@@ -39,7 +39,7 @@ export default class ProfileRunWatcher {
   public constructor(
     private readonly updateFn: UpdateFunction,
     private readonly profile: string,
-    private readonly watcher = chokidar.watch(ProfileRunWatcher.path(profile) + "/*", { depth: 0 })
+    private readonly watcher = chokidar.watch(ProfileRunWatcher.path(profile) + "/*", { depth: 1 })
   ) {}
 
   private static path(profile: string) {
@@ -71,7 +71,7 @@ export default class ProfileRunWatcher {
       const runId = basename(path)
       const idx = this.runs.findIndex((_) => _ === runId)
       if (idx >= 0) {
-        this._runs.push(runId)
+        this._runs.splice(idx, 1)
         this.updateFn()
       }
     })


### PR DESCRIPTION
two separate small bugs. on the former, it turns out that chokidar's `depth` option starts at 1, and we were passing 0. on the latter, we had a copy-paste bug, and were pushing on both the addDir and unlink events.