### PR TITLE
fix: electron crashes with SIGABRT on quit

### DIFF
--- a/plugins/plugin-codeflare/src/tray/watchers/profile/list.ts
+++ b/plugins/plugin-codeflare/src/tray/watchers/profile/list.ts
@@ -32,7 +32,15 @@ export default class ProfileWatcher {
     private readonly updateFn: UpdateFunction,
     private readonly profilesPath: string,
     private readonly watcher = chokidar.watch(profilesPath, { depth: 1 })
-  ) {}
+  ) {
+    // we need to close the chokidar watcher before exit, otherwise
+    // electron-main dies with SIGABRT
+    import("electron").then((_) =>
+      _.app.on("will-quit", async () => {
+        await this.watcher.close()
+      })
+    )
+  }
 
   /** Initialize `this._profiles` model */
   public async init(): Promise<ProfileWatcher> {

--- a/plugins/plugin-codeflare/src/tray/watchers/profile/run.ts
+++ b/plugins/plugin-codeflare/src/tray/watchers/profile/run.ts
@@ -40,7 +40,15 @@ export default class ProfileRunWatcher {
     private readonly updateFn: UpdateFunction,
     private readonly profile: string,
     private readonly watcher = chokidar.watch(ProfileRunWatcher.path(profile) + "/*", { depth: 1 })
-  ) {}
+  ) {
+    // we need to close the chokidar watcher before exit, otherwise
+    // electron-main dies with SIGABRT
+    import("electron").then((_) =>
+      _.app.on("will-quit", async () => {
+        await this.watcher.close()
+      })
+    )
+  }
 
   private static path(profile: string) {
     return Profiles.guidebookJobDataPath({ profile })


### PR DESCRIPTION
It looks like if we don't close the chokidar watchers before exit, the electron main process dies with SIGABRT.