### PR TITLE
fix: hello guidebook shouldn't have non-functional Profile tiles

### DIFF
--- a/plugins/plugin-client-default/notebooks/hello.md
+++ b/plugins/plugin-client-default/notebooks/hello.md
@@ -6,28 +6,13 @@ layout:
         position: default
     2:
         position: default
-        maximized: true
 ---
 
 <img alt="CodeFlare Icon" src="@kui-shell/client/icons/svg/codeflare.svg" width="200" height="200" align="left" />
 CodeFlare is a framework to simplify the integration, scaling and acceleration of complex multi-step analytics and machine learning pipelines on the cloud.
 
-```shell
----
-execute: now
-outputOnly: true
----
-codeflare version
-```
-
 ---
 
-=== "Profiles"
-    ```shell
-    ---
-    execute: now
-    maximize: true
-    outputOnly: true
-    ---
-    codeflare get profile
-    ```
+## Next Steps
+
+From your terminal, try running `codeflare` to be guided through running jobs against the Cloud.


### PR DESCRIPTION
For now, let's replace these with a Next Steps section.