### PR TITLE
fix: periodically rescan the tray menu

### DIFF
--- a/plugins/plugin-codeflare/src/tray/main.ts
+++ b/plugins/plugin-codeflare/src/tray/main.ts
@@ -33,7 +33,8 @@ let tray: null | InstanceType<typeof import("electron").Tray> = null
 class LiveMenu {
   public constructor(
     private readonly tray: import("electron").Tray,
-    private readonly createWindow: CreateWindowFunction
+    private readonly createWindow: CreateWindowFunction,
+    private readonly periodic = setInterval(() => this.render(), 10 * 1000)
   ) {
     this.render()
   }


### PR DESCRIPTION
this helps with the "x seconds ago" menu item labels