### PR TITLE
feat: update tray shutdown handler to use new ml/ray/stop guidebook

### DIFF
--- a/plugins/plugin-codeflare/src/tray/menus/profiles/shutdown.ts
+++ b/plugins/plugin-codeflare/src/tray/menus/profiles/shutdown.ts
@@ -23,7 +23,7 @@ import { shutDownIcon } from "../../icons"
 async function shutdown(profile: string, createWindow: CreateWindowFunction) {
   createWindow(
     // re: -y, this means run in non-interactive mode (-y is short for --yes)
-    ["codeflare", "gui", "guide", "-y", "--profile", profile, "ml/ray/stop/kubernetes"],
+    ["codeflare", "gui", "guide", "-y", "--profile", profile, "ml/ray/stop"],
     windowOptions({ title: "Shutting down " + profile })
   )
 }


### PR DESCRIPTION
Previously, we were hard-coding a kubernetes shutdown.