### PR TITLE
fix: bump to madwizard 0.17.1 to pick up load time optimizations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7489,9 +7489,9 @@
       }
     },
     "node_modules/madwizard": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.16.0.tgz",
-      "integrity": "sha512-h6pV564g9J3NSGz8LNSreVxowVXk3ITJ5kBLugU2jxrctTJj9UB+7WEG3Hm2cmYHOpLTQf/X7vYXdBbaOL4QJw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.17.1.tgz",
+      "integrity": "sha512-mgEzvXBQP79r+0Ch7aIC/o/M01L0VlhQJ09X+s3lEH3pmwS3jyo9pDP1UlOuGKrPThpdiLON0xTi4wgstT1P8Q==",
       "dependencies": {
         "chalk": "^5.0.1",
         "cli-highlight": "^2.1.11",
@@ -13923,7 +13923,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "madwizard": "^0.16.0"
+        "madwizard": "^0.17.1"
       }
     }
   },
@@ -14487,7 +14487,7 @@
     "@kui-shell/plugin-madwizard": {
       "version": "file:plugins/plugin-madwizard",
       "requires": {
-        "madwizard": "^0.16.0"
+        "madwizard": "^0.17.1"
       }
     },
     "@kui-shell/plugin-patternfly4-themes": {
@@ -18725,9 +18725,9 @@
       "integrity": "sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ=="
     },
     "madwizard": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.16.0.tgz",
-      "integrity": "sha512-h6pV564g9J3NSGz8LNSreVxowVXk3ITJ5kBLugU2jxrctTJj9UB+7WEG3Hm2cmYHOpLTQf/X7vYXdBbaOL4QJw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.17.1.tgz",
+      "integrity": "sha512-mgEzvXBQP79r+0Ch7aIC/o/M01L0VlhQJ09X+s3lEH3pmwS3jyo9pDP1UlOuGKrPThpdiLON0xTi4wgstT1P8Q==",
       "requires": {
         "chalk": "^5.0.1",
         "cli-highlight": "^2.1.11",

--- a/plugins/plugin-madwizard/package.json
+++ b/plugins/plugin-madwizard/package.json
@@ -23,6 +23,6 @@
     "access": "public"
   },
   "dependencies": {
-    "madwizard": "^0.16.0"
+    "madwizard": "^0.17.1"
   }
 }


### PR DESCRIPTION
This gives us support for pre-generating the parsed ASTs for the guidebooks, and loading those instead of doing a full parse from source every time a user runs a guidebook.

This should happen transparently, by virtue of running `npm run mirror`