### PR TITLE
fix: `codeflare terminal` does not handle command lines with options

### DIFF
--- a/plugins/plugin-client-default/notebooks/hello.md
+++ b/plugins/plugin-client-default/notebooks/hello.md
@@ -68,5 +68,5 @@ and machine learning pipelines on the cloud.
     outputOnly: true
     maximize: true
     ---
-    codeflare terminal $SHELL
+    codeflare terminal $SHELL -l
     ```

--- a/plugins/plugin-codeflare/src/controller/terminal.tsx
+++ b/plugins/plugin-codeflare/src/controller/terminal.tsx
@@ -48,9 +48,11 @@ export default function openTerminal(args: Arguments) {
       // component, which expects something stream-like
       const passthrough = new PassThrough()
 
-      const { argv, env } = respawn(args.command.replace(/^\s*codeflare\s+terminal\s+/, ""))
+      // respawn, meaning launch it with codeflare
+      const { argv, env } = respawn(args.argv.slice(2))
+      const cmdline = argv.map((_) => encodeComponent(_)).join(" ")
 
-      await args.REPL.qexec(argv.map((_) => encodeComponent(_)).join(" "), undefined, undefined, {
+      await args.REPL.qexec(cmdline, undefined, undefined, {
         tab: args.tab,
         env,
         quiet: true,


### PR DESCRIPTION
This PR also updates hello.md to use `codeflare terminal $SHELL -l`, i.e. adding the `-l` part to ensure that we are launching a login shell. That change needed the fix to handle command lines with options...