### PR TITLE
feat: move hello welcome content to a separate markdown file

### DIFF
--- a/plugins/plugin-client-default/notebooks/about.md
+++ b/plugins/plugin-client-default/notebooks/about.md
@@ -1,0 +1,13 @@
+<img alt="CodeFlare Icon" src="@kui-shell/client/icons/svg/codeflare.svg" width="128" height="128" />
+
+[CodeFlare](https://codeflare.dev) simplifies the
+integration, scaling and acceleration of complex multi-step analytics
+and machine learning pipelines on the cloud.
+
+> ### Getting Started
+>
+> - Use the `codeflare` command in your
+> terminal, or the one embedded here :material-transfer-right:
+> - This CLI guides you through running a job, using a series of
+> questions. 
+> - The answers to your questions are stored as a *profile*.

--- a/plugins/plugin-client-default/notebooks/hello.md
+++ b/plugins/plugin-client-default/notebooks/hello.md
@@ -2,29 +2,12 @@
 title: Hello
 className: codeflare--welcome-guidebook
 layout:
-    1: default
+    1:
+        position: default
+        maximized: true
     2:
         position: default
         maximized: true
-    3:
-        position: default
-        maximized: true
----
-
-<img alt="CodeFlare Icon" src="@kui-shell/client/icons/svg/codeflare.svg" width="128" height="128" align="left" />
-
-[CodeFlare](https://codeflare.dev) simplifies the
-integration, scaling and acceleration of complex multi-step analytics
-and machine learning pipelines on the cloud.
-
-> ### Getting Started
->
-> - Use the `codeflare` command in your
-> terminal, or the one embedded here :material-transfer-right:
-> - This CLI guides you through running a job, using a series of
-> questions. 
-> - The answers to your questions are stored as a *profile*.
-
 ---
 
 === "Your Profiles"
@@ -35,6 +18,7 @@ and machine learning pipelines on the cloud.
     ---
     codeflare get profile
     ```
+
 ---
 
 === "Use the CodeFlare CLI"

--- a/plugins/plugin-client-default/src/CodeFlareWidget.tsx
+++ b/plugins/plugin-client-default/src/CodeFlareWidget.tsx
@@ -29,8 +29,8 @@ export default class CodeFlareWidget extends React.PureComponent {
   private static popoverBody() {
     return (
       <div className="not-very-wide pre-wrap">
-        With CodeFlare, the time it takes to train an AI system can drop from weeks to a single day in a hybrid cloud
-        environment.
+        <a href="https://codeflare.dev">CodeFlare</a> simplifies the integration, scaling and acceleration of complex
+        multi-step analytics and machine learning pipelines on the cloud.
       </div>
     )
   }


### PR DESCRIPTION
 I think can we can show this instead to first-timers in a modal popup (TODO).

This PR also updates the CodeFlareWidget text to use the same content as we have in the welcome markdown.

<img width="1312" alt="codeflare hello v10" src="https://user-images.githubusercontent.com/4741620/182168053-fa08a977-4e52-49de-9363-e41c8dba0a70.png">

