### PR TITLE
feat: dashboard Environment should show full runtime env

### DIFF
--- a/plugins/plugin-client-default/notebooks/dashboard-envvars.md
+++ b/plugins/plugin-client-default/notebooks/dashboard-envvars.md
@@ -3,7 +3,7 @@
     ```json
     ---
     language: yaml
-    include: .runtimeEnv.env_vars
+    include: .runtimeEnv
     ---
     --8<-- "$LOGDIR/job.json"
     ```


### PR DESCRIPTION
right now, we are only showing the env_vars subset