### PR TITLE
fix: switching profiles in profileexplorer may result in Internal Error

### DIFF
--- a/plugins/plugin-codeflare/src/components/RestartableTerminal.tsx
+++ b/plugins/plugin-codeflare/src/components/RestartableTerminal.tsx
@@ -100,9 +100,7 @@ export default class RestartableTerminal extends React.PureComponent<Props, Stat
 
   public componentWillUnmount() {
     this.mounted = false
-    if (this.state.job) {
-      this.state.job.abort()
-    }
+    this.state?.job?.abort()
   }
 
   public render() {


### PR DESCRIPTION
if we have yet to start a terminal pty job, the componentWillUnmount gets a null pointer exception