### PR TITLE
fix: `npm run open` is broken

### DIFF
--- a/plugins/plugin-codeflare/src/controller/index.ts
+++ b/plugins/plugin-codeflare/src/controller/index.ts
@@ -63,12 +63,14 @@ export default function registerCodeflareCommands(registrar: Registrar) {
   })
 
   // launch our explore guidebook
-  registrar.listen("/codeflare/explore", (args) => import("./hello").then((_) => _.default(args)), {
-    needsUI: true,
-    outputOnly: true,
-    width,
-    height,
-  })
+  ;["explore", "explorer", "hello"].forEach((explore) =>
+    registrar.listen(`/codeflare/${explore}`, (args) => import("./hello").then((_) => _.default(args)), {
+      needsUI: true,
+      outputOnly: true,
+      width,
+      height,
+    })
+  )
 
   /**
    * Launch the gallery with asciinema plays


### PR DESCRIPTION
this PR restores the `codeflare hello` command, and also adds `codeflare explorer`, which both launch the same command handler as the existing `codeflare explore`