### PR TITLE
fix: log aggregator may fail in restricted docker hosts

### DIFF
--- a/deploy/log-aggregator/Dockerfile
+++ b/deploy/log-aggregator/Dockerfile
@@ -24,8 +24,8 @@ RUN apt update && apt -y install sudo curl procps inotify-tools \
         && codeflare -n util/websocat \
         && codeflare -n kubernetes/kubectl
 
-USER codeflare
-WORKDIR /home/codeflare
+#USER codeflare
+WORKDIR /home/node
 
 CMD exec /bin/bash -c "trap : TERM INT; sleep infinity & wait"
 # ENTRYPOINT ["codeflare", "-y", "-p", "default", "ml/ray/aggregator/with-jobid"]

--- a/deploy/log-aggregator/wait-for.sh
+++ b/deploy/log-aggregator/wait-for.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 
 F="$1"
+D=$(dirname $F)
 
 # wait for the file to exist and be non-empty
 while [ ! -s "$F" ]; do
-    mkdir -p $(dirname $F)
-    inotifywait -qq -e create -e modify "$(dirname $F)"
+    if [ ! -d "$D" ]; then mkdir -p "$D" || break; fi
+    inotifywait -qq -e create -e modify "$D"
 done
+
+echo "Error in watch"
+exit 1


### PR DESCRIPTION
We are setting a USER in our Dockerfile that does not seem to work with containers secured by a SELinux host.