### PR TITLE
chore: bump to @guidebooks/store 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^0.2.4",
+        "@guidebooks/store": "^0.3.0",
         "@kui-shell/client": "file:./plugins/plugin-client-default",
         "@kui-shell/core": "11.5.0-dev-20220807-191654",
         "@kui-shell/plugin-bash-like": "11.5.0-dev-20220807-191654",
@@ -564,9 +564,9 @@
       "license": "MIT"
     },
     "node_modules/@guidebooks/store": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.2.4.tgz",
-      "integrity": "sha512-0onx8Z6Kr3cXe3jGnd3PHVQYCw4/agKqfaBN4xlUcSMilnoalCrDCpaOJsvGvOlr0jW1dPe7BpMNweKFdlCreg=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.3.0.tgz",
+      "integrity": "sha512-sEyusg7zSE6f3h6ZHkJZMKhXQIFCLpOmuihbab7ndZCZz/htdkbMGdR1XjV743Gt0wYumaqxl+9/1/V8z8RZjg=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.10.4",
@@ -14539,9 +14539,9 @@
       "version": "1.1.3"
     },
     "@guidebooks/store": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.2.4.tgz",
-      "integrity": "sha512-0onx8Z6Kr3cXe3jGnd3PHVQYCw4/agKqfaBN4xlUcSMilnoalCrDCpaOJsvGvOlr0jW1dPe7BpMNweKFdlCreg=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.3.0.tgz",
+      "integrity": "sha512-sEyusg7zSE6f3h6ZHkJZMKhXQIFCLpOmuihbab7ndZCZz/htdkbMGdR1XjV743Gt0wYumaqxl+9/1/V8z8RZjg=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.10.4",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "typescript": "4.7.4"
   },
   "dependencies": {
-    "@guidebooks/store": "^0.2.4",
+    "@guidebooks/store": "^0.3.0",
     "@kui-shell/client": "file:./plugins/plugin-client-default",
     "@kui-shell/core": "11.5.0-dev-20220807-191654",
     "@kui-shell/plugin-bash-like": "11.5.0-dev-20220807-191654",


### PR DESCRIPTION
This picks up some in-kube-cluster support for ray