### PR TITLE
fix: improved UX for attaching to running jobs

### DIFF
--- a/plugins/plugin-codeflare/src/controller/run/get.ts
+++ b/plugins/plugin-codeflare/src/controller/run/get.ts
@@ -23,6 +23,7 @@ import { setTabReadonly } from "@kui-shell/plugin-madwizard"
 
 import { productName } from "@kui-shell/client/config.d/name.json"
 
+import Status from "../status"
 import { width, height } from "../dashboard"
 import { getJobDefinition } from "../description"
 
@@ -48,8 +49,6 @@ function capitalize(str: string) {
   return str[0].toUpperCase() + str.slice(1)
 }
 
-/** TODO: these are specific to Ray */
-type Status = "SUCCEEDED" | "STOPPED" | "RUNNING" | "PENDING" | "ERROR"
 function statusColor(status: Status) {
   switch (status) {
     case "SUCCEEDED":

--- a/plugins/plugin-codeflare/src/controller/status.ts
+++ b/plugins/plugin-codeflare/src/controller/status.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** TODO: these are specific to Ray */
+type Status = "SUCCEEDED" | "STOPPED" | "RUNNING" | "PENDING" | "ERROR"
+
+export default Status

--- a/plugins/plugin-codeflare/src/tray/menus/profiles/active-runs.ts
+++ b/plugins/plugin-codeflare/src/tray/menus/profiles/active-runs.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { basename } from "path"
 import { MenuItemConstructorOptions } from "electron"
 import { CreateWindowFunction } from "@kui-shell/core"
+import { productName } from "@kui-shell/client/config.d/name.json"
 
 import { rayIcon } from "../../icons"
 import UpdateFunction from "../../update"
@@ -27,10 +27,10 @@ import { runMenuItems } from "./runs"
 /** active run watcher per profile */
 const watchers: Record<string, ProfileActiveRunWatcher> = {}
 
-/** This is the utility function that will open a CodeFlare Dashboard window, pointing to the given local filesystem `logdir` */
-async function openDashboard(createWindow: CreateWindowFunction, logdir: string, follow = true) {
-  await createWindow(["codeflare", "dashboard", follow ? "-f" : "", logdir], {
-    title: "CodeFlare Dashboard - " + basename(logdir),
+/** This is the utility function that will open a CodeFlare Dashboard window and attaches to the given job */
+async function openDashboard(createWindow: CreateWindowFunction, profile: string, runId: string, follow = true) {
+  await createWindow(["codeflare", "dashboard", follow ? "-f" : "", "-a", runId, "-p", profile], {
+    title: productName + " Dashboard - " + runId,
   })
 }
 
@@ -53,7 +53,7 @@ async function openMenuItem(this: CreateWindowFunction, profile: string, runId: 
   // ^^^ disabled... due to the FIXME
 
   // otherwise, we will need to start of a log aggregator
-  process.env.NO_WAIT = "true" // don't wait for job termination
+  /* process.env.NO_WAIT = "true" // don't wait for job termination
   process.env.QUIET_CONSOLE = "true" // don't tee logs to the console
   const { attach } = await import("../../../controller/attach")
   const { logdir, cleanExit } = await attach(profile, runId, { verbose: true })
@@ -72,7 +72,8 @@ async function openMenuItem(this: CreateWindowFunction, profile: string, runId: 
     if (typeof cleanExit === "function") {
       cleanExit()
     }
-  }
+    } */
+  await openDashboard(this, profile, runId)
 }
 
 /** @return menu items that allow attaching to an active run in the given `profileName` */

--- a/plugins/plugin-codeflare/src/tray/watchers/profile/active-runs.ts
+++ b/plugins/plugin-codeflare/src/tray/watchers/profile/active-runs.ts
@@ -38,7 +38,7 @@ export default class ProfileActiveRunWatcher {
     private readonly updateFn: UpdateFunction,
     private readonly profile: string,
     public readonly rayAddress = ProfileActiveRunWatcher.initWatcher(profile),
-    private readonly timer = setInterval(() => this.updateActiveJobs(), 5000)
+    private readonly timer = setInterval(() => this.updateActiveJobs(), 3000)
   ) {
     onRun(() => this.updateActiveJobs())
   }


### PR DESCRIPTION
Instead of showing nothing for an extended period of time, we now open a window immediately and show some (for now textual) progress info.

This PR also fixes some issues that could result in bogus output (`cannot read property runtime_env of undefined`) in job description.