### PR TITLE
chore: bump madwizard 0.19.3 -> 0.19.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2063,9 +2063,9 @@
       }
     },
     "node_modules/allotment": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/allotment/-/allotment-1.15.0.tgz",
-      "integrity": "sha512-9JXAm59/XD5Djfpso0rgGZdA23n3v5XeicwjNoInp2qlBa/HFZtnMDujm6NHOSjOCQPWhkOt4ybYgz8H3ed+8A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/allotment/-/allotment-1.16.0.tgz",
+      "integrity": "sha512-007NiFlogG5MVpXccJOedPELFtU1it1fyIA6eBMf1LbDjE7ujs81tQr+DMsOhGxcxSsK/vKdzXwQH0Vigiw5uA==",
       "dependencies": {
         "classnames": "^2.3.0",
         "eventemitter3": "^4.0.0",
@@ -7774,9 +7774,9 @@
       }
     },
     "node_modules/madwizard": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.19.3.tgz",
-      "integrity": "sha512-pNZ9WwO+MF0vyydkj2g/iq2MuBtpY9pEJU2stvQecvw/EY6feSqxfUEB3cWBogm607EYCOWNbKfNjmr9D4GbtA==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.19.4.tgz",
+      "integrity": "sha512-5S8dDUYdTK/qKygu4QPgXeJLyvCiLSrUEsBlj5enviVhrGzSRkWuxE6bXS/lcwieQR86zcAsB9EQY8cyMmlgZg==",
       "dependencies": {
         "chalk": "^5.0.1",
         "cli-highlight": "^2.1.11",
@@ -14110,9 +14110,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@logdna/tail-file": "^3.0.0",
-        "@patternfly/react-charts": "^6.77.1",
-        "@patternfly/react-core": "^4.224.1",
-        "allotment": "^1.15.0",
+        "@patternfly/react-charts": "^6.84.8",
+        "@patternfly/react-core": "^4.231.8",
+        "allotment": "^1.16.0",
         "asciinema-player": "^3.0.1",
         "chokidar": "^3.5.3",
         "needle": "^3.1.0",
@@ -14166,7 +14166,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@guidebooks/store": "^0.4.0",
-        "madwizard": "^0.19.3"
+        "madwizard": "^0.19.4"
       }
     }
   },
@@ -14712,9 +14712,9 @@
       "version": "file:plugins/plugin-codeflare",
       "requires": {
         "@logdna/tail-file": "^3.0.0",
-        "@patternfly/react-charts": "^6.77.1",
-        "@patternfly/react-core": "^4.224.1",
-        "allotment": "^1.15.0",
+        "@patternfly/react-charts": "^6.84.8",
+        "@patternfly/react-core": "^4.231.8",
+        "allotment": "^1.16.0",
         "asciinema-player": "^3.0.1",
         "chokidar": "^3.5.3",
         "needle": "^3.1.0",
@@ -14804,7 +14804,7 @@
       "version": "file:plugins/plugin-madwizard",
       "requires": {
         "@guidebooks/store": "^0.4.0",
-        "madwizard": "^0.19.3"
+        "madwizard": "^0.19.4"
       }
     },
     "@kui-shell/plugin-patternfly4-themes": {
@@ -15708,9 +15708,9 @@
       "requires": {}
     },
     "allotment": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/allotment/-/allotment-1.15.0.tgz",
-      "integrity": "sha512-9JXAm59/XD5Djfpso0rgGZdA23n3v5XeicwjNoInp2qlBa/HFZtnMDujm6NHOSjOCQPWhkOt4ybYgz8H3ed+8A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/allotment/-/allotment-1.16.0.tgz",
+      "integrity": "sha512-007NiFlogG5MVpXccJOedPELFtU1it1fyIA6eBMf1LbDjE7ujs81tQr+DMsOhGxcxSsK/vKdzXwQH0Vigiw5uA==",
       "requires": {
         "classnames": "^2.3.0",
         "eventemitter3": "^4.0.0",
@@ -19351,9 +19351,9 @@
       "integrity": "sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ=="
     },
     "madwizard": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.19.3.tgz",
-      "integrity": "sha512-pNZ9WwO+MF0vyydkj2g/iq2MuBtpY9pEJU2stvQecvw/EY6feSqxfUEB3cWBogm607EYCOWNbKfNjmr9D4GbtA==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-0.19.4.tgz",
+      "integrity": "sha512-5S8dDUYdTK/qKygu4QPgXeJLyvCiLSrUEsBlj5enviVhrGzSRkWuxE6bXS/lcwieQR86zcAsB9EQY8cyMmlgZg==",
       "requires": {
         "chalk": "^5.0.1",
         "cli-highlight": "^2.1.11",

--- a/plugins/plugin-codeflare/package.json
+++ b/plugins/plugin-codeflare/package.json
@@ -24,9 +24,9 @@
   },
   "dependencies": {
     "@logdna/tail-file": "^3.0.0",
-    "@patternfly/react-charts": "^6.77.1",
-    "@patternfly/react-core": "^4.224.1",
-    "allotment": "^1.15.0",
+    "@patternfly/react-charts": "^6.84.8",
+    "@patternfly/react-core": "^4.231.8",
+    "allotment": "^1.16.0",
     "asciinema-player": "^3.0.1",
     "chokidar": "^3.5.3",
     "needle": "^3.1.0",

--- a/plugins/plugin-madwizard/package.json
+++ b/plugins/plugin-madwizard/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "madwizard": "^0.19.3",
+    "madwizard": "^0.19.4",
     "@guidebooks/store": "^0.4.0"
   }
 }


### PR DESCRIPTION
picks up a bug fix for showing emacs temporaries in the profiles menu
also a few other minor bumps (allotment 1.15 -> 1.16)