### PR TITLE
fix: release-it does not correctly publish cask updates

### DIFF
--- a/Casks/bump.sh
+++ b/Casks/bump.sh
@@ -17,6 +17,7 @@ arm64=$(sha256sum "$SCRIPTDIR"/../dist/electron/CodeFlare-darwin-arm64.tar.bz2 |
 cp "$SCRIPTDIR"/codeflare.rb "$SCRIPTDIR"/codeflare.rb.bak
 
 cat "$SCRIPTDIR"/codeflare.tpl \
+    | sed -r "s/{{ version }}/$version/g" \
     | sed -r "s/{{ x64 }}/$x64/g" \
     | sed -r "s/{{ arm64 }}/$arm64/g" \
           > "$SCRIPTDIR"/codeflare.rb

--- a/Casks/codeflare.tpl
+++ b/Casks/codeflare.tpl
@@ -1,5 +1,5 @@
 cask "codeflare" do
-  version "0.9.3"
+  version "{{ version }}"
 
   name "CodeFlare"
   desc "CLI for Project CodeFlare"

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "release-it": {
     "hooks": {
-      "before:release": [
+      "after:bump": [
         "npm ci",
         "rm -rf ./dist/electron",
         "rm -rf ./dist/headless",


### PR DESCRIPTION
We were using before:release, but it should be after:bump. Also, our cask bump.sh script was not templating in the new version.