### PR TITLE
fix: release-it is not propagating version

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,13 +98,13 @@
         "rm -rf ./dist/electron",
         "rm -rf ./dist/headless",
         "npm run build:electron:all",
-        "VERSION=$version npm run release:cask",
-        "VERSION=$version npm run build:docker:self-test",
-        "VERSION=$version npm run build:docker:log-aggregator"
+        "VERSION=${version} npm run release:cask",
+        "VERSION=${version} npm run build:docker:self-test",
+        "VERSION=${version} npm run build:docker:log-aggregator"
       ],
       "after:release": [
-        "VERSION=$version npm run publish:docker:self-test",
-        "VERSION=$version npm run publish:docker:log-aggregator"
+        "VERSION=${version} npm run publish:docker:self-test",
+        "VERSION=${version} npm run publish:docker:log-aggregator"
       ]
     },
     "npm": {


### PR DESCRIPTION
Weird, we are using `$version`, but it appears that release-it requires this to be `${version}`