### PR TITLE
fix: roberta self-test cronjob does not properly specify history limit specs

### DIFF
--- a/deploy/self-test/roberta/1gpu/periodic.yaml
+++ b/deploy/self-test/roberta/1gpu/periodic.yaml
@@ -43,11 +43,11 @@ metadata:
   name: codeflare-self-test-roberta-1gpu-periodic
 spec:
   schedule: "0/30 * * * *" # every 30 minutes, starting from the top of the hour (see crontab.guru)
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1000
+  successfulJobsHistoryLimit: 1000
   jobTemplate:
     spec:
-      concurrencyPolicy: Forbid
-      failedJobsHistoryLimit: 1000
-      successfulJobsHistoryLimit: 1000
       template:
         spec:
           serviceAccountName: codeflare-self-test-serviceaccount


### PR DESCRIPTION
we had them under the job template, and for some reason kubectl did not complain about a schematic error