### PR TITLE
fix: tray menu does not appear in production builds on linux and windows

### DIFF
--- a/plugins/plugin-codeflare/src/tray/icons.ts
+++ b/plugins/plugin-codeflare/src/tray/icons.ts
@@ -26,11 +26,17 @@ import gettingStarted from "@kui-shell/client/icons/png/gettingStartedTemplate.p
 
 import { join } from "path"
 
-const iconHome = process.env.CODEFLARE_HEADLESS || join(process.argv0, "../../Resources/app/dist/headless")
+function resources() {
+  return process.platform === "darwin" ? join(process.argv0, "../../Resources") : join(process.argv0, "../resources")
+}
+
+export function iconHome() {
+  return process.env.CODEFLARE_HEADLESS || join(resources(), "app/dist/headless")
+}
 
 /** Resize and templatize, so that the icon morphs with platform color themes */
 function iconFor(filepath: string) {
-  return join(iconHome, filepath)
+  return join(iconHome(), filepath)
 }
 
 export const rayIcon = iconFor(ray)

--- a/plugins/plugin-codeflare/src/tray/main.ts
+++ b/plugins/plugin-codeflare/src/tray/main.ts
@@ -17,6 +17,7 @@
 import { join } from "path"
 import { CreateWindowFunction } from "@kui-shell/core"
 
+import { iconHome } from "./icons"
 import buildContextMenu from "./menus"
 import { productName } from "@kui-shell/client/config.d/name.json"
 
@@ -73,18 +74,13 @@ export default async function main(createWindow: CreateWindowFunction) {
       try {
         const { Tray } = await import("electron")
 
-        const iconHome = process.env.CODEFLARE_HEADLESS || join(process.argv0, "../../Resources/app/dist/headless")
-        if (iconHome) {
-          // this forces webpack to include the @2x template images in
-          // the build
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const fake = "dist/headless/" + icon2x
+        // this forces webpack to include the @2x template images in
+        // the build
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const fake = "dist/headless/" + icon2x
 
-          tray = new Tray(join(iconHome, icon))
-          new LiveMenu(tray, createWindow)
-        } else {
-          console.error("Cannot register electron tray menu, because CODEFLARE_HEADLESS environment variable is absent")
-        }
+        tray = new Tray(join(iconHome(), icon))
+        new LiveMenu(tray, createWindow)
       } catch (err) {
         console.error("Error registering electron tray menu", err)
       }


### PR DESCRIPTION
We had two places in the tray menu code where we were assuming the macOS file layout for production builds (which is somewhat different from that on linux and windows)