### PR TITLE
fix: no window close button on linux and windows

### DIFF
--- a/plugins/plugin-client-default/config.d/style.json
+++ b/plugins/plugin-client-default/config.d/style.json
@@ -2,7 +2,6 @@
   "bodyCss": "codeflare",
   "width": 1204,
   "height": 800,
-  "frame": false,
   "titleBarStyle": "hiddenInset",
   "defaultTheme": "PatternFly4 Light"
 }


### PR DESCRIPTION
I don't know why we were using a frameless electron window. On macOS, all that is needed is

```
  "titleBarStyle": "hiddenInset",
```