### PR TITLE
chore: re-update package.json to bump roberta self-test image versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,11 @@
         "infile": "CHANGELOG.md"
       },
       "@release-it/bumper": {
-        "out": "plugins/plugin-client-default/package.json"
+        "out": [
+          "deploy/self-test/roberta/1gpu/once.yaml",
+          "deploy/self-test/roberta/1gpu/periodic.yaml",
+          "plugins/plugin-client-default/package.json"
+        ]
       }
     }
   },


### PR DESCRIPTION
ugh, we did this before, but incorrectly. we had three fields named `out`, and prettier squashed them