### PR TITLE
chore: bump @guidebooks/store to 0.6.6 to pick up byot -> byoc renaming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -595,9 +595,9 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
     },
     "node_modules/@guidebooks/store": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.6.5.tgz",
-      "integrity": "sha512-fwZzsrO2ytXsUV48dHEpkXYljb86Im4r8AgbFo6/QzlB4A7KDeqxN1bDU5jqwFVWoajKRGBvco2RettgAiZRLw==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.6.6.tgz",
+      "integrity": "sha512-NryBBvJ18SuHUYdjoIrzhrI2ZAMjfvFoAqsxXNPfMe125UpzkgzU5bmbdMOO3XDvUVpq4C8Wxmqx1/2IBvtV5Q==",
       "peerDependencies": {
         "madwizard": ">=0.19.5"
       }
@@ -15348,7 +15348,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^0.6.5",
+        "@guidebooks/store": "^0.6.6",
         "madwizard": "^0.21.3"
       }
     }
@@ -15759,9 +15759,9 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
     },
     "@guidebooks/store": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.6.5.tgz",
-      "integrity": "sha512-fwZzsrO2ytXsUV48dHEpkXYljb86Im4r8AgbFo6/QzlB4A7KDeqxN1bDU5jqwFVWoajKRGBvco2RettgAiZRLw==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.6.6.tgz",
+      "integrity": "sha512-NryBBvJ18SuHUYdjoIrzhrI2ZAMjfvFoAqsxXNPfMe125UpzkgzU5bmbdMOO3XDvUVpq4C8Wxmqx1/2IBvtV5Q==",
       "requires": {}
     },
     "@humanwhocodes/config-array": {
@@ -16043,7 +16043,7 @@
     "@kui-shell/plugin-madwizard": {
       "version": "file:plugins/plugin-madwizard",
       "requires": {
-        "@guidebooks/store": "^0.6.5",
+        "@guidebooks/store": "^0.6.6",
         "madwizard": "^0.21.3"
       }
     },

--- a/plugins/plugin-madwizard/package.json
+++ b/plugins/plugin-madwizard/package.json
@@ -24,6 +24,6 @@
   },
   "dependencies": {
     "madwizard": "^0.21.3",
-    "@guidebooks/store": "^0.6.5"
+    "@guidebooks/store": "^0.6.6"
   }
 }


### PR DESCRIPTION
It will now be `ml/codeflare/training/byoc`