### PR TITLE
fix: back out release-it bumper for yamls

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,8 +125,6 @@
       },
       "@release-it/bumper": {
         "out": [
-          "deploy/self-test/roberta/1gpu/once.yaml",
-          "deploy/self-test/roberta/1gpu/periodic.yaml",
           "plugins/plugin-client-default/package.json"
         ]
       }


### PR DESCRIPTION
We are trying to use `@release-it/bumper` to bump the image versions in some of our yaml files. These are multi-document yamls, which that bumper npm does not support due to https://github.com/release-it/bumper/issues/24.

For now, we will need to bump those versions manually.