### PR TITLE
chore: bump roberta self-test image versions

### DIFF
--- a/deploy/self-test/roberta/1gpu/once.yaml
+++ b/deploy/self-test/roberta/1gpu/once.yaml
@@ -49,7 +49,7 @@ spec:
       serviceAccountName: codeflare-self-test-serviceaccount
       containers:
       - name: self-test
-        image: ghcr.io/project-codeflare/codeflare-self-test:0.11.1
+        image: ghcr.io/project-codeflare/codeflare-self-test:0.11.2
         env:
           # - name: GUIDEBOOK_RUN_ARGS
           #  value: "-V"

--- a/deploy/self-test/roberta/1gpu/periodic.yaml
+++ b/deploy/self-test/roberta/1gpu/periodic.yaml
@@ -53,7 +53,7 @@ spec:
           serviceAccountName: codeflare-self-test-serviceaccount
           containers:
           - name: self-test
-            image: ghcr.io/project-codeflare/codeflare-self-test:0.11.1
+            image: ghcr.io/project-codeflare/codeflare-self-test:0.11.2
             env:
               # - name: GUIDEBOOK_RUN_ARGS
               #  value: "-V"


### PR DESCRIPTION
We need to do this manually, for now. See https://github.com/project-codeflare/codeflare-cli/pull/533