### PR TITLE
fix: bump to @guidebooks/store 0.7.2 to pick up roberta fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -595,9 +595,9 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
     },
     "node_modules/@guidebooks/store": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.7.1.tgz",
-      "integrity": "sha512-l/IS0VWbqf7SqRq/jNsML27G5j83oYKOyQDH2RJ/DCG2opzmEtYqmysywfXhbcet+TDETPl1YKTYXv2HgN14ew==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.7.2.tgz",
+      "integrity": "sha512-MDOGn3v8KZ8HD/RlwkThaZTHxn1cppPldCjyCwRwAwDVNaIa4c350y04WOfEad/DMGeNwees4xCUhAn24buPDg==",
       "peerDependencies": {
         "madwizard": ">=0.19.5"
       }
@@ -15294,7 +15294,7 @@
     },
     "plugins/plugin-client-default": {
       "name": "@kui-shell/plugin-client",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "Apache-2.0"
     },
     "plugins/plugin-codeflare": {
@@ -15348,7 +15348,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^0.7.1",
+        "@guidebooks/store": "^0.7.2",
         "madwizard": "^0.21.5"
       }
     }
@@ -15759,9 +15759,9 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
     },
     "@guidebooks/store": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.7.1.tgz",
-      "integrity": "sha512-l/IS0VWbqf7SqRq/jNsML27G5j83oYKOyQDH2RJ/DCG2opzmEtYqmysywfXhbcet+TDETPl1YKTYXv2HgN14ew==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.7.2.tgz",
+      "integrity": "sha512-MDOGn3v8KZ8HD/RlwkThaZTHxn1cppPldCjyCwRwAwDVNaIa4c350y04WOfEad/DMGeNwees4xCUhAn24buPDg==",
       "requires": {}
     },
     "@humanwhocodes/config-array": {
@@ -16043,7 +16043,7 @@
     "@kui-shell/plugin-madwizard": {
       "version": "file:plugins/plugin-madwizard",
       "requires": {
-        "@guidebooks/store": "^0.7.1",
+        "@guidebooks/store": "^0.7.2",
         "madwizard": "^0.21.5"
       }
     },

--- a/plugins/plugin-madwizard/package.json
+++ b/plugins/plugin-madwizard/package.json
@@ -24,6 +24,6 @@
   },
   "dependencies": {
     "madwizard": "^0.21.5",
-    "@guidebooks/store": "^0.7.1"
+    "@guidebooks/store": "^0.7.2"
   }
 }


### PR DESCRIPTION
This also picks up `ml/codeflare/training/roberta/demo`