### PR TITLE
fix: "create namespace" option causes odd failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -586,9 +586,9 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
     },
     "node_modules/@guidebooks/store": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.11.0.tgz",
-      "integrity": "sha512-lKKWdJNerU416wQ+Vo7uTp1TMyJKtPMR3cWrjTlpHok6ILLG2NhiXSzZF81Vs3Z2uBRBMcGxZbPfuJuy3PvppQ==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.11.3.tgz",
+      "integrity": "sha512-Wr0ku6H029I+IguakPNxQy/f8s7poCSaF4I5cI94svpseOAo7pn2daw9nboSQ2gymTII4hSFbaW1vKWtn5EtPw==",
       "peerDependencies": {
         "madwizard": ">=0.19.5"
       }
@@ -15882,7 +15882,7 @@
     },
     "plugins/plugin-client-default": {
       "name": "@kui-shell/plugin-client",
-      "version": "0.11.4",
+      "version": "0.12.1",
       "license": "Apache-2.0"
     },
     "plugins/plugin-codeflare": {
@@ -15936,7 +15936,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^0.11.0",
+        "@guidebooks/store": "^0.11.3",
         "madwizard": "^0.22.1"
       }
     }
@@ -16338,9 +16338,9 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
     },
     "@guidebooks/store": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.11.0.tgz",
-      "integrity": "sha512-lKKWdJNerU416wQ+Vo7uTp1TMyJKtPMR3cWrjTlpHok6ILLG2NhiXSzZF81Vs3Z2uBRBMcGxZbPfuJuy3PvppQ==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.11.3.tgz",
+      "integrity": "sha512-Wr0ku6H029I+IguakPNxQy/f8s7poCSaF4I5cI94svpseOAo7pn2daw9nboSQ2gymTII4hSFbaW1vKWtn5EtPw==",
       "requires": {}
     },
     "@humanwhocodes/config-array": {
@@ -16629,7 +16629,7 @@
     "@kui-shell/plugin-madwizard": {
       "version": "file:plugins/plugin-madwizard",
       "requires": {
-        "@guidebooks/store": "^0.11.0",
+        "@guidebooks/store": "^0.11.3",
         "madwizard": "^0.22.1"
       }
     },

--- a/plugins/plugin-madwizard/package.json
+++ b/plugins/plugin-madwizard/package.json
@@ -24,6 +24,6 @@
   },
   "dependencies": {
     "madwizard": "^0.22.1",
-    "@guidebooks/store": "^0.11.0"
+    "@guidebooks/store": "^0.11.3"
   }
 }


### PR DESCRIPTION
- bump to @guidebooks/store 0.11.1, to pick up fixes for kubernetes/choose/ns, the option for creating a namespace.
- improvements to finding a local install of the `ray` CLI on macOS.
- lower defaults for ray cluster resource requests