### PR TITLE
fix: respawn uses incorrect (Renderer) executable when called from UI mode

### DIFF
--- a/plugins/plugin-codeflare/src/controller/respawn.ts
+++ b/plugins/plugin-codeflare/src/controller/respawn.ts
@@ -80,7 +80,13 @@ async function guidebookStore() {
 export default async function respawnCommand(cmdline: string | string[]) {
   return {
     argv: [
-      encodeComponent(process.argv[0]),
+      // re: replace, in UI mode on macOS, the argv[0] points to the renderer executable
+      encodeComponent(
+        process.argv[0].replace(
+          /\/Frameworks\/(\w+) Helper \(Renderer\)\.app\/Contents\/MacOS\/\w+ Helper \(Renderer\)$/,
+          "/MacOS/$1"
+        )
+      ),
       encodeComponent((await headlessRoot()) + "/codeflare.min.js"),
       "--",
       ...(typeof cmdline === "string" ? [cmdline] : cmdline),


### PR DESCRIPTION
I think this only affects macOS, for which chromium has a separate executable for the Renderer process.