### PR TITLE
fix: profiles in tray menu may show duplicates

### DIFF
--- a/plugins/plugin-codeflare/src/tray/watchers/profile/list.ts
+++ b/plugins/plugin-codeflare/src/tray/watchers/profile/list.ts
@@ -62,11 +62,12 @@ export default class ProfileWatcher {
         return
       }
 
+      const profileObj = await Profiles.restore(this.madwizardOptions, basename(path)).then((_) => _.profile)
       const idx = this.profiles.findIndex((_) => _.name === profile)
       if (idx < 0) {
-        this._profiles.push(await Profiles.restore(this.madwizardOptions, basename(path)).then((_) => _.profile))
+        this._profiles.push(profileObj)
       } else {
-        this._profiles[idx] = await Profiles.restore(this.madwizardOptions, basename(path)).then((_) => _.profile)
+        this._profiles[idx] = profileObj
       }
       this.updateFn()
     } catch (err) {


### PR DESCRIPTION
We had a race condition in the chokidar file update handler.