### PR TITLE
fix: Terminal component still has toolbar UI even when `searchable===false`

### DIFF
--- a/plugins/plugin-codeflare/src/components/Terminal.tsx
+++ b/plugins/plugin-codeflare/src/components/Terminal.tsx
@@ -343,14 +343,18 @@ export default class XTerm extends React.PureComponent<Props, State> {
   }
 
   private toolbar() {
+    const needsToolbar = this.props.searchable !== false
+
     return (
-      <Toolbar className="codeflare--toolbar">
-        <ToolbarContent className="flex-fill">
-          <ToolbarItem variant="search-filter" className="flex-fill">
-            {this.props.searchable !== false && this.searchInput()}
-          </ToolbarItem>
-        </ToolbarContent>
-      </Toolbar>
+      needsToolbar && (
+        <Toolbar className="codeflare--toolbar">
+          <ToolbarContent className="flex-fill">
+            <ToolbarItem variant="search-filter" className="flex-fill">
+              {this.props.searchable !== false && this.searchInput()}
+            </ToolbarItem>
+          </ToolbarContent>
+        </Toolbar>
+      )
     )
   }
 


### PR DESCRIPTION


This takes up a few pixels of vertical space. In dark themes, it is also visible, despite having no functionality.