### PR TITLE
chore: rename main UI component TaskTerminal -> WorkloadDesigner

### DIFF
--- a/plugins/plugin-client-default/notebooks/hello.md
+++ b/plugins/plugin-client-default/notebooks/hello.md
@@ -13,5 +13,5 @@ execute: now
 outputOnly: true
 maximize: true
 ---
-codeflare terminal task
+codeflare designer
 ```

--- a/plugins/plugin-codeflare/src/controller/index.ts
+++ b/plugins/plugin-codeflare/src/controller/index.ts
@@ -99,7 +99,7 @@ export default function registerCodeflareCommands(registrar: Registrar) {
   registrar.listen("/codeflare/dashboard-gallery", (args) => import("./hello").then((_) => _.dashboardGallery(args)))
 
   /** UI for running profile-related tasks */
-  registrar.listen("/codeflare/terminal/task", (args) => import("./terminal").then((_) => _.task(args)), {
+  registrar.listen("/codeflare/designer", (args) => import("./terminal").then((_) => _.designer(args)), {
     needsUI: true,
   })
 

--- a/plugins/plugin-codeflare/src/controller/terminal.tsx
+++ b/plugins/plugin-codeflare/src/controller/terminal.tsx
@@ -30,8 +30,6 @@ import Terminal, { Props as BaseProps } from "../components/RestartableTerminal"
 import "../../web/scss/components/Allotment/_index.scss"
 import "allotment/dist/style.css"
 
-// codeflare -p ${SELECTED_PROFILE}
-
 class AllotmentFillPane extends React.PureComponent<{ minSize?: number }> {
   public render() {
     return (
@@ -98,7 +96,7 @@ type State = Partial<Pick<BaseProps, "cmdline" | "env">> & {
   hideTerminal?: boolean
 }
 
-export class TaskTerminal extends React.PureComponent<Props, State> {
+export class WorkloadDesigner extends React.PureComponent<Props, State> {
   /** Allotment initial split ... allotments */
   private readonly splits = {
     horizontal: [25, 75],
@@ -329,8 +327,8 @@ class Empty extends React.PureComponent<{ refresh(): void; gotit(): void }> {
 
 /**
  * This is a command handler that opens up a terminal to run a selected profile-oriented task */
-export function task(args: Arguments) {
+export function designer(args: Arguments) {
   return {
-    react: <TaskTerminal REPL={args.REPL} tab={args.tab} />,
+    react: <WorkloadDesigner REPL={args.REPL} tab={args.tab} />,
   }
 }

--- a/plugins/plugin-codeflare/src/index.ts
+++ b/plugins/plugin-codeflare/src/index.ts
@@ -16,4 +16,4 @@
 
 /* Your exported API */
 
-export { TaskTerminal as WorkloadDesigner, Props as WorkloadDesignerProps } from "./controller/terminal"
+export { WorkloadDesigner, Props as WorkloadDesignerProps } from "./controller/terminal"


### PR DESCRIPTION
we were already calling it that in src/index, i.e. the exported API of plugin-codeflare