### PR TITLE
feat: bump to @guidebooks/store@0.18.0 to pick up ray auto-stop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -594,9 +594,9 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
     },
     "node_modules/@guidebooks/store": {
-      "version": "0.17.7",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.17.7.tgz",
-      "integrity": "sha512-WBw110AFUrM9BcW9efoj0IGm0RlvgEeMM6ROfb5hDjxOOrOE+NvsNZGolJc/3UVqIr+ZDeRScCBBA/qNZ6QdrA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.18.0.tgz",
+      "integrity": "sha512-ZE9SLPfGEBsy/8q/FXT8DkYqUqMXREsvEl3EEMgO9zxm2k2SteepU7j9kKFtWMvTe+DRQM2R1bAeWdOOI8LxhA==",
       "peerDependencies": {
         "madwizard": ">=1.8.3"
       }
@@ -16514,7 +16514,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^0.17.7",
+        "@guidebooks/store": "^0.18.0",
         "madwizard": "^1.8.5"
       }
     }
@@ -16924,9 +16924,9 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
     },
     "@guidebooks/store": {
-      "version": "0.17.7",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.17.7.tgz",
-      "integrity": "sha512-WBw110AFUrM9BcW9efoj0IGm0RlvgEeMM6ROfb5hDjxOOrOE+NvsNZGolJc/3UVqIr+ZDeRScCBBA/qNZ6QdrA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.18.0.tgz",
+      "integrity": "sha512-ZE9SLPfGEBsy/8q/FXT8DkYqUqMXREsvEl3EEMgO9zxm2k2SteepU7j9kKFtWMvTe+DRQM2R1bAeWdOOI8LxhA==",
       "requires": {}
     },
     "@humanwhocodes/config-array": {
@@ -17312,7 +17312,7 @@
     "@kui-shell/plugin-madwizard": {
       "version": "file:plugins/plugin-madwizard",
       "requires": {
-        "@guidebooks/store": "^0.17.7",
+        "@guidebooks/store": "^0.18.0",
         "madwizard": "^1.8.5"
       }
     },

--- a/plugins/plugin-madwizard/package.json
+++ b/plugins/plugin-madwizard/package.json
@@ -24,6 +24,6 @@
   },
   "dependencies": {
     "madwizard": "^1.8.5",
-    "@guidebooks/store": "^0.17.7"
+    "@guidebooks/store": "^0.18.0"
   }
 }


### PR DESCRIPTION
That release of the store also includes switching ray from Deployment to Job, bumping mcad to pick up `completionstatus` support, and updating the helm charts to use that support.