### PR TITLE
feat: bump to `@guidebooks/store@1.1.0` to pick up ray/v1 support and bert updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -594,9 +594,9 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
     },
     "node_modules/@guidebooks/store": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.18.2.tgz",
-      "integrity": "sha512-wx9PjlG0OCwVx9H1RpY5oNwB6xdtt95QxmVFJ+07NdZiuB1lg2Sd1sNo9TDf9BY67Tqxow+GGXU/k+6CNctyaA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-1.1.0.tgz",
+      "integrity": "sha512-R8La5rngQtFtwo5ueAdiVswhBVf2ey859y+U3Mo+2/h3MGFRtPgoH2qAN5TS/c0+5rFxtGpE9XVSy8t7O7sbzA==",
       "peerDependencies": {
         "madwizard": ">=1.8.3"
       }
@@ -16514,7 +16514,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^0.18.2",
+        "@guidebooks/store": "^1.1.0",
         "madwizard": "^1.9.1"
       }
     }
@@ -16924,9 +16924,9 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
     },
     "@guidebooks/store": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-0.18.2.tgz",
-      "integrity": "sha512-wx9PjlG0OCwVx9H1RpY5oNwB6xdtt95QxmVFJ+07NdZiuB1lg2Sd1sNo9TDf9BY67Tqxow+GGXU/k+6CNctyaA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-1.1.0.tgz",
+      "integrity": "sha512-R8La5rngQtFtwo5ueAdiVswhBVf2ey859y+U3Mo+2/h3MGFRtPgoH2qAN5TS/c0+5rFxtGpE9XVSy8t7O7sbzA==",
       "requires": {}
     },
     "@humanwhocodes/config-array": {
@@ -17312,7 +17312,7 @@
     "@kui-shell/plugin-madwizard": {
       "version": "file:plugins/plugin-madwizard",
       "requires": {
-        "@guidebooks/store": "^0.18.2",
+        "@guidebooks/store": "^1.1.0",
         "madwizard": "^1.9.1"
       }
     },

--- a/plugins/plugin-madwizard/package.json
+++ b/plugins/plugin-madwizard/package.json
@@ -24,6 +24,6 @@
   },
   "dependencies": {
     "madwizard": "^1.9.1",
-    "@guidebooks/store": "^0.18.2"
+    "@guidebooks/store": "^1.1.0"
   }
 }


### PR DESCRIPTION
https://github.com/guidebooks/store/pull/447