### PR TITLE
fix: bump kui to pick up fix for -h/-v options, and fix for ray head node label selector not being job-specific

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -17,7 +17,7 @@ jobs:
           - non-gpu2/keep-it-simple
           - non-gpu3/keep-it-simple
           - non-gpu4/keep-it-simple
-          - non-gpu1/ray-autoscaler
+          # - non-gpu1/ray-autoscaler
           - non-gpu1/mcad-default
           - non-gpu1/mcad-coscheduler
           - non-gpu1/mcad-preinstalled

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,23 +11,23 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@kui-shell/client": "file:./plugins/plugin-client-default",
-        "@kui-shell/core": "13.0.0-dev-20230217-141510",
-        "@kui-shell/plugin-bash-like": "13.0.0-dev-20230217-141510",
-        "@kui-shell/plugin-client-common": "13.0.0-dev-20230217-141510",
+        "@kui-shell/core": "13.0.0-dev-20230220-145930",
+        "@kui-shell/plugin-bash-like": "13.0.0-dev-20230220-145930",
+        "@kui-shell/plugin-client-common": "13.0.0-dev-20230220-145930",
         "@kui-shell/plugin-codeflare": "file:./plugins/plugin-codeflare",
-        "@kui-shell/plugin-core-support": "13.0.0-dev-20230217-141510",
-        "@kui-shell/plugin-electron-components": "13.0.0-dev-20230217-141510",
-        "@kui-shell/plugin-kubectl": "13.0.0-dev-20230217-141510",
-        "@kui-shell/plugin-madwizard": "13.0.0-dev-20230217-141510",
-        "@kui-shell/plugin-patternfly4-themes": "13.0.0-dev-20230217-141510",
-        "@kui-shell/plugin-proxy-support": "13.0.0-dev-20230217-141510",
+        "@kui-shell/plugin-core-support": "13.0.0-dev-20230220-145930",
+        "@kui-shell/plugin-electron-components": "13.0.0-dev-20230220-145930",
+        "@kui-shell/plugin-kubectl": "13.0.0-dev-20230220-145930",
+        "@kui-shell/plugin-madwizard": "13.0.0-dev-20230220-145930",
+        "@kui-shell/plugin-patternfly4-themes": "13.0.0-dev-20230220-145930",
+        "@kui-shell/plugin-proxy-support": "13.0.0-dev-20230220-145930",
         "node-pty": "0.11.0-beta27"
       },
       "devDependencies": {
-        "@kui-shell/builder": "13.0.0-dev-20230217-141510",
-        "@kui-shell/proxy": "13.0.0-dev-20230217-141510",
-        "@kui-shell/react": "13.0.0-dev-20230217-141510",
-        "@kui-shell/webpack": "13.0.0-dev-20230217-141510",
+        "@kui-shell/builder": "13.0.0-dev-20230220-145930",
+        "@kui-shell/proxy": "13.0.0-dev-20230220-145930",
+        "@kui-shell/react": "13.0.0-dev-20230220-145930",
+        "@kui-shell/webpack": "13.0.0-dev-20230220-145930",
         "@playwright/test": "^1.30.0",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.51.0",
@@ -899,9 +899,9 @@
       "license": "MIT"
     },
     "node_modules/@guidebooks/store": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-4.0.3.tgz",
-      "integrity": "sha512-QdXwTZffJ+TmdpmohsH7Hu9OGdWcm4jNIz3JwOlaKmUWvl7SoF2XFKoY4xt6A9o5BPcXO7CvNRSGSbGy5OeLsw=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-5.0.0.tgz",
+      "integrity": "sha512-kJQmcyPJQNQC4+hCGu9sXUZxvom+UxNAPp51z2oGrWs6zhNbLkF3GvmVRyBCYYSEvffXpZBsvl1+R9r81aFDQw=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -1087,9 +1087,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@kui-shell/builder": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/builder/-/builder-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-cNgWDjHdTG3P701ZgGEkoW19M/nQPJPXNMQ7k7Sp5oLf/N2wgOsMVOUwpStLll8ytA+5buwGTiWQupALEIa0hA==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/builder/-/builder-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-pDKY8fH2xdqpIfGNz1QiS04H56VsJXNKhmcxYX4mLGN9aqahx0AIDIpAsdMOOLd65FMmxUUnV2wk9sFeQQO5zg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1123,9 +1123,9 @@
       "link": true
     },
     "node_modules/@kui-shell/core": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/core/-/core-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-0H2osCrWeKXj5germyUFpY1sMYqzXf51dMu8ytmKYMLSTWvi3nKpwOr6sbMB4pocdf4Wd5LtjBW8g4bR65VCiA==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/core/-/core-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-ZTtTHNtTGe6AVd7+/O2S6oweTVeXR2upNFBsmiJjH4rOKWGaO9aIbSXTr23Vr/8Q9PsrXK2oQ8TLROW+R+qznQ==",
       "dependencies": {
         "colors": "^1.4.0",
         "columnify": "^1.6.0",
@@ -1164,9 +1164,9 @@
       }
     },
     "node_modules/@kui-shell/plugin-bash-like": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-bash-like/-/plugin-bash-like-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-hRTySBbz6PSVYGtq2lRbKuW13JjMj9DLW9rqaJtxbnfPd4WXqieVTUb46R5bHeUYWEdP1dmcD/oojIbFWsHuTA==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-bash-like/-/plugin-bash-like-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-tOHGSA6w1zUa2D4/xEFCJIvK0qj1gL/5b3TbFlWcinXZxcj2sm80RhOXum0rkO+X4u1XHtkcd6v1SOUyPcfwqA==",
       "dependencies": {
         "@kui-shell/xterm-helpers": "^2.1.0",
         "cookie": "^0.5.0",
@@ -1186,9 +1186,9 @@
       }
     },
     "node_modules/@kui-shell/plugin-client-common": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-client-common/-/plugin-client-common-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-zMyHCN9GRUMOa85GHZmlwROPZ4JPCv7IJhCfS4kXH8MYRWJ1s2MGuDuteBUdhxSodzkLFucV6/JOa9Cdggh7+A==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-client-common/-/plugin-client-common-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-5fM56Q8Q60YHEa9ll9iYmgmq2iUpxZgP/0BPNsArpk8jMlR1X819b/Ce2vnXuZ/f13+Zd+l7mT1TdTlF9moFqg==",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.2.1",
         "@mdi/font": "^7.1.96",
@@ -1234,9 +1234,9 @@
       "link": true
     },
     "node_modules/@kui-shell/plugin-core-support": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-core-support/-/plugin-core-support-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-lq2afsHC1c0N7n4Elv4H8uULS8LA7lSEdO3o0/zwQ3Ap+eCKEvoxA3T1QR018E81zVslBGlp2gctgrB7h5hBQw==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-core-support/-/plugin-core-support-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-Uk/x0FKNkneEr3X/9NCZfLBJu/VwN19wXWbRiaN2IgSWv1c18haSNH82ocWTAiSdHH1eqkSwpjo1+aOHifysKg==",
       "dependencies": {
         "@supercharge/promise-pool": "^2.3.2",
         "debug": "^4.3.4",
@@ -1244,21 +1244,21 @@
       }
     },
     "node_modules/@kui-shell/plugin-electron-components": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-electron-components/-/plugin-electron-components-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-zkU/0q934ViaM+EUUsa3yGtCFUmodaWzqWoxHHAlFJl78VaVHWLgXu7iwvyKwKeW4fTrRvpSoMg7rmy7FvrQzg==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-electron-components/-/plugin-electron-components-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-1t8miqF5CsCPG91J+J5UUv+vF3mMI0W8w3mo4XF5RDHsz5NgZuh8aZfCeFZoYj1sgsWVjtstqXfdilh7tLrGXg==",
       "dependencies": {
         "@patternfly/react-core": "^4.264.0",
         "needle": "^3.2.0"
       }
     },
     "node_modules/@kui-shell/plugin-kubectl": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl/-/plugin-kubectl-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-LKCDiMQCRd5zBcz/x8T7IZOsSPJqeA56WU8oaHnS5PVxVLKfjaPll7A4XIHUlyERd8FS6uhtjX6WMfI1HA5OJw==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl/-/plugin-kubectl-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-ZNijquZNW9l1XfurlSLKz4kFwslRSXWZd45XapgCvfYcZPPykKJsZvVrVyM15mCz7LFiO22PcQpNSntjuOnOOg==",
       "dependencies": {
         "@kui-shell/jsonpath": "^1.1.1",
-        "@kui-shell/plugin-kubectl-core": "^13.0.0-dev-20230217-141510",
+        "@kui-shell/plugin-kubectl-core": "^13.0.0-dev-20230220-145930",
         "bytes-iec": "^3.1.1",
         "command-exists": "^1.2.9",
         "debug": "^4.3.4",
@@ -1276,9 +1276,9 @@
       }
     },
     "node_modules/@kui-shell/plugin-kubectl-core": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl-core/-/plugin-kubectl-core-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-NdV1gzPVQM3vDbMCW9t8gS7MKMZRhxWcuyFFhLb0VneL2m8WNuxhvJtPGQ1m4a31oOxPFcdNKuxIr2T9atMXYg=="
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl-core/-/plugin-kubectl-core-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-n6KTPO3WMwUfd/YZ338rvyYHeGENMmwvgF6GAayj2m7/JO/jBNjS67V75RF75wIGphkrRvxhNGd+pyHR/qjGXw=="
     },
     "node_modules/@kui-shell/plugin-kubectl/node_modules/fs-extra": {
       "version": "11.1.0",
@@ -1320,9 +1320,9 @@
       "license": "ISC"
     },
     "node_modules/@kui-shell/plugin-madwizard": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-madwizard/-/plugin-madwizard-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-wIeZHR1mqPHzYW3BJzOG4nWY/n0Jxq4xuBi7NZjBfGUy0hqzLQERpzXcuZse6Wh7Rz/vRCEj8t/Mt/7Ygzovhw==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-madwizard/-/plugin-madwizard-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-0Z/4IfHxH5cirY3V6cDwSvAXQ2dyFhi/f7iJLnNHrSljOiKOj9lGig9eE9YxSJo+zavP1E1kgO4gli7eVhLwaw==",
       "dependencies": {
         "@patternfly/react-core": "^4.267.6",
         "allotment": "^1.17.1",
@@ -1348,19 +1348,19 @@
       }
     },
     "node_modules/@kui-shell/plugin-patternfly4-themes": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-patternfly4-themes/-/plugin-patternfly4-themes-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-mJK0ciEVIlfUoHVmR2sn8wAXzbivlSwJL0safkOw3/6S/HCS/HYwEoIi5OU+3wa4w1ZEMKiAt9SCrfZ56w/7hA=="
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-patternfly4-themes/-/plugin-patternfly4-themes-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-bjvQIpmOrtC8Bte8SOW8eHD3XZfM6GlWMZV2jvtNmul7BAIgG/KJ+R6Cs5hBxsg/SQLgqvQI7R8/vEl+SGTPGg=="
     },
     "node_modules/@kui-shell/plugin-proxy-support": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-proxy-support/-/plugin-proxy-support-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-+BINQ83VGSfvRJAFMk/RDQNdvJ55BSRQckZ+IZK/e110bj6Smiu6v1a+Ob6Os6is5Cwf14WDrV6w4lRbqVjsRA=="
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-proxy-support/-/plugin-proxy-support-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-EOVxaVJ+7LjeZ/dk2dYIzp1BBxetDovCI3PQMsQ9rPhRmuAmRCmnTITkNtU7bVh9aBCGIY0wkuqXuYDCi3ugFA=="
     },
     "node_modules/@kui-shell/proxy": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/proxy/-/proxy-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-pWdfYoHAfXsRHKr1usnQ7M5GDAH4nOX3M/rrP1GgBYsGboPPfU1X3HeYuabnM4E3XbHA4Y6k3G8d4RAtZ+ye8g==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/proxy/-/proxy-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-mQPaP35/GLADEfnUmd2MZ7xkcf/Twe5W/R0HYn8RS8S0Fr0+fcnWBfP4GB3bYlwxt+Wusu6h4qppwpxp79jw4A==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1371,9 +1371,9 @@
       }
     },
     "node_modules/@kui-shell/react": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/react/-/react-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-vMnm/pIwcEx+BNzzKn+jN6YJq6iPL5SYGtfiUKLG4JrZwna5N1YYbZe9t3GTqSc0h+mzu7VRyEP9O4G8dFH9yA==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/react/-/react-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-261pjtd89+KizTL0jC6M5eKNqWNpdMbnAvdGc4DDlU5P6uB8pin4mEJe4ylRhpTobkTvIWxg4eZHTI85uTQeEg==",
       "dev": true,
       "dependencies": {
         "react": "^18.2.0",
@@ -1381,9 +1381,9 @@
       }
     },
     "node_modules/@kui-shell/webpack": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/webpack/-/webpack-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-g9TD7rAoc6AuenF8d8rvGG1Bw4FnAEWQxPyatcWhM+8Pl9TBbuI4n5y0dCg0M3myCPOvuEJI7UBg78SXFcpX8w==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/webpack/-/webpack-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-kfk7WVenXkNqvkReZQQk/8LUd89Na72RSUEquvUx36rN2BhYp2aob9IxQIwkhJlBtGID43unazXFRqFj9W4l3A==",
       "dev": true,
       "dependencies": {
         "assert": "^2.0.0",
@@ -8121,9 +8121,9 @@
       }
     },
     "node_modules/madwizard": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-6.2.0.tgz",
-      "integrity": "sha512-tpxGwQpA1G3NbjEjLzbGJ04J/fSxLVMW6K797MU1rRyQcmbZCNvFc+j1Yr2KH3MyVRTKatAw7anpYV/xYUkOLw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-6.2.1.tgz",
+      "integrity": "sha512-kYDi4uMIBjNjtiHI5C156TREyAAdignYk8ezXF9Z1c9p8QSpt5ltimWBIIB2+rXQEvRoSOdmu2xCSz2I6xYrmQ==",
       "dependencies": {
         "chalk": "^5.2.0",
         "columnify": "^1.6.0",
@@ -14470,7 +14470,7 @@
     },
     "plugins/plugin-client-default": {
       "name": "@kui-shell/plugin-client",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "license": "Apache-2.0"
     },
     "plugins/plugin-codeflare": {
@@ -14478,13 +14478,13 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^4.0.3",
+        "@guidebooks/store": "^5.0.0",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.18",
         "@patternfly/react-core": "^4.276.6",
         "asciinema-player": "^3.0.1",
         "chokidar": "^3.5.3",
-        "madwizard": "^6.2.0",
+        "madwizard": "^6.2.1",
         "needle": "^3.2.0",
         "open": "^8.4.0",
         "pretty-bytes": "^6.0.0",
@@ -15088,9 +15088,9 @@
       "dev": true
     },
     "@guidebooks/store": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-4.0.3.tgz",
-      "integrity": "sha512-QdXwTZffJ+TmdpmohsH7Hu9OGdWcm4jNIz3JwOlaKmUWvl7SoF2XFKoY4xt6A9o5BPcXO7CvNRSGSbGy5OeLsw=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-5.0.0.tgz",
+      "integrity": "sha512-kJQmcyPJQNQC4+hCGu9sXUZxvom+UxNAPp51z2oGrWs6zhNbLkF3GvmVRyBCYYSEvffXpZBsvl1+R9r81aFDQw=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -15212,9 +15212,9 @@
       "version": "3.4.0"
     },
     "@kui-shell/builder": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/builder/-/builder-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-cNgWDjHdTG3P701ZgGEkoW19M/nQPJPXNMQ7k7Sp5oLf/N2wgOsMVOUwpStLll8ytA+5buwGTiWQupALEIa0hA==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/builder/-/builder-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-pDKY8fH2xdqpIfGNz1QiS04H56VsJXNKhmcxYX4mLGN9aqahx0AIDIpAsdMOOLd65FMmxUUnV2wk9sFeQQO5zg==",
       "dev": true,
       "requires": {
         "@babel/cli": "^7.20.7",
@@ -15237,9 +15237,9 @@
       "version": "file:plugins/plugin-client-default"
     },
     "@kui-shell/core": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/core/-/core-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-0H2osCrWeKXj5germyUFpY1sMYqzXf51dMu8ytmKYMLSTWvi3nKpwOr6sbMB4pocdf4Wd5LtjBW8g4bR65VCiA==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/core/-/core-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-ZTtTHNtTGe6AVd7+/O2S6oweTVeXR2upNFBsmiJjH4rOKWGaO9aIbSXTr23Vr/8Q9PsrXK2oQ8TLROW+R+qznQ==",
       "requires": {
         "colors": "^1.4.0",
         "columnify": "^1.6.0",
@@ -15272,9 +15272,9 @@
       }
     },
     "@kui-shell/plugin-bash-like": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-bash-like/-/plugin-bash-like-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-hRTySBbz6PSVYGtq2lRbKuW13JjMj9DLW9rqaJtxbnfPd4WXqieVTUb46R5bHeUYWEdP1dmcD/oojIbFWsHuTA==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-bash-like/-/plugin-bash-like-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-tOHGSA6w1zUa2D4/xEFCJIvK0qj1gL/5b3TbFlWcinXZxcj2sm80RhOXum0rkO+X4u1XHtkcd6v1SOUyPcfwqA==",
       "requires": {
         "@kui-shell/xterm-helpers": "^2.1.0",
         "cookie": "^0.5.0",
@@ -15294,9 +15294,9 @@
       }
     },
     "@kui-shell/plugin-client-common": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-client-common/-/plugin-client-common-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-zMyHCN9GRUMOa85GHZmlwROPZ4JPCv7IJhCfS4kXH8MYRWJ1s2MGuDuteBUdhxSodzkLFucV6/JOa9Cdggh7+A==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-client-common/-/plugin-client-common-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-5fM56Q8Q60YHEa9ll9iYmgmq2iUpxZgP/0BPNsArpk8jMlR1X819b/Ce2vnXuZ/f13+Zd+l7mT1TdTlF9moFqg==",
       "requires": {
         "@fortawesome/fontawesome-free": "^6.2.1",
         "@mdi/font": "^7.1.96",
@@ -15336,7 +15336,7 @@
     "@kui-shell/plugin-codeflare": {
       "version": "file:plugins/plugin-codeflare",
       "requires": {
-        "@guidebooks/store": "^4.0.3",
+        "@guidebooks/store": "^5.0.0",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.18",
         "@patternfly/react-core": "^4.276.6",
@@ -15347,7 +15347,7 @@
         "@types/split2": "^3.2.1",
         "asciinema-player": "^3.0.1",
         "chokidar": "^3.5.3",
-        "madwizard": "^6.2.0",
+        "madwizard": "^6.2.1",
         "needle": "^3.2.0",
         "open": "^8.4.0",
         "pretty-bytes": "^6.0.0",
@@ -15368,9 +15368,9 @@
       }
     },
     "@kui-shell/plugin-core-support": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-core-support/-/plugin-core-support-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-lq2afsHC1c0N7n4Elv4H8uULS8LA7lSEdO3o0/zwQ3Ap+eCKEvoxA3T1QR018E81zVslBGlp2gctgrB7h5hBQw==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-core-support/-/plugin-core-support-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-Uk/x0FKNkneEr3X/9NCZfLBJu/VwN19wXWbRiaN2IgSWv1c18haSNH82ocWTAiSdHH1eqkSwpjo1+aOHifysKg==",
       "requires": {
         "@supercharge/promise-pool": "^2.3.2",
         "debug": "^4.3.4",
@@ -15378,21 +15378,21 @@
       }
     },
     "@kui-shell/plugin-electron-components": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-electron-components/-/plugin-electron-components-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-zkU/0q934ViaM+EUUsa3yGtCFUmodaWzqWoxHHAlFJl78VaVHWLgXu7iwvyKwKeW4fTrRvpSoMg7rmy7FvrQzg==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-electron-components/-/plugin-electron-components-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-1t8miqF5CsCPG91J+J5UUv+vF3mMI0W8w3mo4XF5RDHsz5NgZuh8aZfCeFZoYj1sgsWVjtstqXfdilh7tLrGXg==",
       "requires": {
         "@patternfly/react-core": "^4.264.0",
         "needle": "^3.2.0"
       }
     },
     "@kui-shell/plugin-kubectl": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl/-/plugin-kubectl-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-LKCDiMQCRd5zBcz/x8T7IZOsSPJqeA56WU8oaHnS5PVxVLKfjaPll7A4XIHUlyERd8FS6uhtjX6WMfI1HA5OJw==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl/-/plugin-kubectl-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-ZNijquZNW9l1XfurlSLKz4kFwslRSXWZd45XapgCvfYcZPPykKJsZvVrVyM15mCz7LFiO22PcQpNSntjuOnOOg==",
       "requires": {
         "@kui-shell/jsonpath": "^1.1.1",
-        "@kui-shell/plugin-kubectl-core": "^13.0.0-dev-20230217-141510",
+        "@kui-shell/plugin-kubectl-core": "^13.0.0-dev-20230220-145930",
         "bytes-iec": "^3.1.1",
         "command-exists": "^1.2.9",
         "debug": "^4.3.4",
@@ -15435,14 +15435,14 @@
       }
     },
     "@kui-shell/plugin-kubectl-core": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl-core/-/plugin-kubectl-core-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-NdV1gzPVQM3vDbMCW9t8gS7MKMZRhxWcuyFFhLb0VneL2m8WNuxhvJtPGQ1m4a31oOxPFcdNKuxIr2T9atMXYg=="
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl-core/-/plugin-kubectl-core-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-n6KTPO3WMwUfd/YZ338rvyYHeGENMmwvgF6GAayj2m7/JO/jBNjS67V75RF75wIGphkrRvxhNGd+pyHR/qjGXw=="
     },
     "@kui-shell/plugin-madwizard": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-madwizard/-/plugin-madwizard-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-wIeZHR1mqPHzYW3BJzOG4nWY/n0Jxq4xuBi7NZjBfGUy0hqzLQERpzXcuZse6Wh7Rz/vRCEj8t/Mt/7Ygzovhw==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-madwizard/-/plugin-madwizard-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-0Z/4IfHxH5cirY3V6cDwSvAXQ2dyFhi/f7iJLnNHrSljOiKOj9lGig9eE9YxSJo+zavP1E1kgO4gli7eVhLwaw==",
       "requires": {
         "@patternfly/react-core": "^4.267.6",
         "allotment": "^1.17.1",
@@ -15463,25 +15463,25 @@
       }
     },
     "@kui-shell/plugin-patternfly4-themes": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-patternfly4-themes/-/plugin-patternfly4-themes-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-mJK0ciEVIlfUoHVmR2sn8wAXzbivlSwJL0safkOw3/6S/HCS/HYwEoIi5OU+3wa4w1ZEMKiAt9SCrfZ56w/7hA=="
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-patternfly4-themes/-/plugin-patternfly4-themes-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-bjvQIpmOrtC8Bte8SOW8eHD3XZfM6GlWMZV2jvtNmul7BAIgG/KJ+R6Cs5hBxsg/SQLgqvQI7R8/vEl+SGTPGg=="
     },
     "@kui-shell/plugin-proxy-support": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-proxy-support/-/plugin-proxy-support-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-+BINQ83VGSfvRJAFMk/RDQNdvJ55BSRQckZ+IZK/e110bj6Smiu6v1a+Ob6Os6is5Cwf14WDrV6w4lRbqVjsRA=="
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-proxy-support/-/plugin-proxy-support-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-EOVxaVJ+7LjeZ/dk2dYIzp1BBxetDovCI3PQMsQ9rPhRmuAmRCmnTITkNtU7bVh9aBCGIY0wkuqXuYDCi3ugFA=="
     },
     "@kui-shell/proxy": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/proxy/-/proxy-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-pWdfYoHAfXsRHKr1usnQ7M5GDAH4nOX3M/rrP1GgBYsGboPPfU1X3HeYuabnM4E3XbHA4Y6k3G8d4RAtZ+ye8g==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/proxy/-/proxy-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-mQPaP35/GLADEfnUmd2MZ7xkcf/Twe5W/R0HYn8RS8S0Fr0+fcnWBfP4GB3bYlwxt+Wusu6h4qppwpxp79jw4A==",
       "dev": true
     },
     "@kui-shell/react": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/react/-/react-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-vMnm/pIwcEx+BNzzKn+jN6YJq6iPL5SYGtfiUKLG4JrZwna5N1YYbZe9t3GTqSc0h+mzu7VRyEP9O4G8dFH9yA==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/react/-/react-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-261pjtd89+KizTL0jC6M5eKNqWNpdMbnAvdGc4DDlU5P6uB8pin4mEJe4ylRhpTobkTvIWxg4eZHTI85uTQeEg==",
       "dev": true,
       "requires": {
         "react": "^18.2.0",
@@ -15489,9 +15489,9 @@
       }
     },
     "@kui-shell/webpack": {
-      "version": "13.0.0-dev-20230217-141510",
-      "resolved": "https://registry.npmjs.org/@kui-shell/webpack/-/webpack-13.0.0-dev-20230217-141510.tgz",
-      "integrity": "sha512-g9TD7rAoc6AuenF8d8rvGG1Bw4FnAEWQxPyatcWhM+8Pl9TBbuI4n5y0dCg0M3myCPOvuEJI7UBg78SXFcpX8w==",
+      "version": "13.0.0-dev-20230220-145930",
+      "resolved": "https://registry.npmjs.org/@kui-shell/webpack/-/webpack-13.0.0-dev-20230220-145930.tgz",
+      "integrity": "sha512-kfk7WVenXkNqvkReZQQk/8LUd89Na72RSUEquvUx36rN2BhYp2aob9IxQIwkhJlBtGID43unazXFRqFj9W4l3A==",
       "dev": true,
       "requires": {
         "assert": "^2.0.0",
@@ -19845,9 +19845,9 @@
       }
     },
     "madwizard": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-6.2.0.tgz",
-      "integrity": "sha512-tpxGwQpA1G3NbjEjLzbGJ04J/fSxLVMW6K797MU1rRyQcmbZCNvFc+j1Yr2KH3MyVRTKatAw7anpYV/xYUkOLw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-6.2.1.tgz",
+      "integrity": "sha512-kYDi4uMIBjNjtiHI5C156TREyAAdignYk8ezXF9Z1c9p8QSpt5ltimWBIIB2+rXQEvRoSOdmu2xCSz2I6xYrmQ==",
       "requires": {
         "chalk": "^5.2.0",
         "columnify": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -131,10 +131,10 @@
     }
   },
   "devDependencies": {
-    "@kui-shell/builder": "13.0.0-dev-20230217-141510",
-    "@kui-shell/proxy": "13.0.0-dev-20230217-141510",
-    "@kui-shell/react": "13.0.0-dev-20230217-141510",
-    "@kui-shell/webpack": "13.0.0-dev-20230217-141510",
+    "@kui-shell/builder": "13.0.0-dev-20230220-145930",
+    "@kui-shell/proxy": "13.0.0-dev-20230220-145930",
+    "@kui-shell/react": "13.0.0-dev-20230220-145930",
+    "@kui-shell/webpack": "13.0.0-dev-20230220-145930",
     "@playwright/test": "^1.30.0",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",
@@ -152,15 +152,15 @@
   "dependencies": {
     "node-pty": "0.11.0-beta27",
     "@kui-shell/client": "file:./plugins/plugin-client-default",
-    "@kui-shell/core": "13.0.0-dev-20230217-141510",
-    "@kui-shell/plugin-bash-like": "13.0.0-dev-20230217-141510",
-    "@kui-shell/plugin-client-common": "13.0.0-dev-20230217-141510",
+    "@kui-shell/core": "13.0.0-dev-20230220-145930",
+    "@kui-shell/plugin-bash-like": "13.0.0-dev-20230220-145930",
+    "@kui-shell/plugin-client-common": "13.0.0-dev-20230220-145930",
     "@kui-shell/plugin-codeflare": "file:./plugins/plugin-codeflare",
-    "@kui-shell/plugin-core-support": "13.0.0-dev-20230217-141510",
-    "@kui-shell/plugin-electron-components": "13.0.0-dev-20230217-141510",
-    "@kui-shell/plugin-kubectl": "13.0.0-dev-20230217-141510",
-    "@kui-shell/plugin-madwizard": "13.0.0-dev-20230217-141510",
-    "@kui-shell/plugin-patternfly4-themes": "13.0.0-dev-20230217-141510",
-    "@kui-shell/plugin-proxy-support": "13.0.0-dev-20230217-141510"
+    "@kui-shell/plugin-core-support": "13.0.0-dev-20230220-145930",
+    "@kui-shell/plugin-electron-components": "13.0.0-dev-20230220-145930",
+    "@kui-shell/plugin-kubectl": "13.0.0-dev-20230220-145930",
+    "@kui-shell/plugin-madwizard": "13.0.0-dev-20230220-145930",
+    "@kui-shell/plugin-patternfly4-themes": "13.0.0-dev-20230220-145930",
+    "@kui-shell/plugin-proxy-support": "13.0.0-dev-20230220-145930"
   }
 }

--- a/plugins/plugin-codeflare/package.json
+++ b/plugins/plugin-codeflare/package.json
@@ -30,13 +30,13 @@
     "@types/split2": "^3.2.1"
   },
   "dependencies": {
-    "@guidebooks/store": "^4.0.3",
+    "@guidebooks/store": "^5.0.0",
     "@logdna/tail-file": "^3.0.1",
     "@patternfly/react-charts": "^6.94.18",
     "@patternfly/react-core": "^4.276.6",
     "asciinema-player": "^3.0.1",
     "chokidar": "^3.5.3",
-    "madwizard": "^6.2.0",
+    "madwizard": "^6.2.1",
     "needle": "^3.2.0",
     "open": "^8.4.0",
     "pretty-bytes": "^6.0.0",

--- a/tests/kind/profiles/non-gpu1/ray-autoscaler
+++ b/tests/kind/profiles/non-gpu1/ray-autoscaler
@@ -14,7 +14,7 @@
     "ml/codeflare/training/byoc/form": "{\"Path to source\":\"tests/kind/inputs/qiskit\",\"Base image\":\"rayproject/ray:2.1.0\"}",
     "kubernetes/choose/secret/image-pull": "No secret needed, since my image is public",
     "s3/choose/bucket/maybe": "My data is not stored in S3",
-    "ml/ray/start/resources": "{\"Number of CPUs\":\"200m\",\"Number of GPUs\":\"0\",\"Minimum Workers\":\"1\",\"Maximum Workers\":\"1\",\"Worker Memory\":\"500Mi\",\"Head Memory\":\"3Gi\",\"Ephemeral Storage\":\"5Gi\"}",
+    "ml/ray/start/resources": "{\"Number of CPUs\":\"200m\",\"Number of GPUs\":\"0\",\"Minimum Workers\":\"0\",\"Maximum Workers\":\"0\",\"Worker Memory\":\"500Mi\",\"Head Memory\":\"2.5Gi\",\"Ephemeral Storage\":\"5Gi\"}",
     "kubernetes/context": "kind-codeflare-test",
     "kubernetes/choose/ns": "default",
     "ml/ray/storage/s3/maybe": "My code does not use Ray Workflows",

--- a/tests/kind/run.sh
+++ b/tests/kind/run.sh
@@ -71,6 +71,12 @@ function run {
     export MWPROFILES_PATH="$MWPROFILES_PATH_BASE"/$variant
     mkdir -p "$MWPROFILES_PATH"
 
+    if [ "$profile" = "ray-autoscaler" ]; then
+        # ugh, the old ray operator uses a different naming convention
+        export RAY_KUBE_CLUSTER_HEAD_SERVICE=$RAY_KUBE_CLUSTER_NAME-ray-head
+        echo "[Test] Run: using Ray operator's convention for naming ray-head service $RAY_KUBE_CLUSTER_HEAD_SERVICE"
+    fi
+
     local guidebook=${2-$GUIDEBOOK}
     local yes=$([ -z "$FORCE_ALL" ] && [ "$FORCE" != "$profileFull" ] && [ -f "$MWPROFILES_PATH/$profile" ] && echo "--yes" || echo "")
 
@@ -96,6 +102,12 @@ function attach {
     export MWPROFILES_PATH="$MWPROFILES_PATH_BASE"/$variant
 
     local jobId=$2
+
+    if [ "$profile" = "ray-autoscaler" ]; then
+        # ugh, the old ray operator uses a different naming convention
+        export RAY_KUBE_CLUSTER_HEAD_SERVICE=$RAY_KUBE_CLUSTER_NAME-ray-head
+        echo "[Test] Attach: using Ray operator's convention for naming ray-head service $RAY_KUBE_CLUSTER_HEAD_SERVICE"
+    fi
 
     LOGFILE=$(mktemp)
 


### PR DESCRIPTION
also: bump kui to pick up fix for -h/-v options, and also bump madwizard for that fix, too Fixes #791

BREAKING CHANGE: from `@guidebooks/store@5` remove ray autoscaler support (needed to make tests pass, since ray2 has some breakage that has gone undetected till now)