### PR TITLE
feat: bump to `@guidebooks/store@5.2.0` to pick up more flexible (non-ray) vmstat tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -899,9 +899,9 @@
       "license": "MIT"
     },
     "node_modules/@guidebooks/store": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-5.1.7.tgz",
-      "integrity": "sha512-1eYr6bqc2thkJhh7WTXqrOjlqSX1LeFz8AbkhvWaJt5Zgr17UnNNGlNB9lRITOPt+hxNRzXnrRcN3//79vc+Dw=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-5.2.0.tgz",
+      "integrity": "sha512-6m/EDcpA0fffo3qY9UREZy9hoNoYf9NW3m69Z1sbAybN6rh2kixsmJEvv+CbKDUYH3QE4f7SDhliKKu7+xBriQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -14484,7 +14484,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^5.1.7",
+        "@guidebooks/store": "^5.2.0",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.18",
         "@patternfly/react-core": "^4.276.6",
@@ -15094,9 +15094,9 @@
       "dev": true
     },
     "@guidebooks/store": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-5.1.7.tgz",
-      "integrity": "sha512-1eYr6bqc2thkJhh7WTXqrOjlqSX1LeFz8AbkhvWaJt5Zgr17UnNNGlNB9lRITOPt+hxNRzXnrRcN3//79vc+Dw=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-5.2.0.tgz",
+      "integrity": "sha512-6m/EDcpA0fffo3qY9UREZy9hoNoYf9NW3m69Z1sbAybN6rh2kixsmJEvv+CbKDUYH3QE4f7SDhliKKu7+xBriQ=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -15342,7 +15342,7 @@
     "@kui-shell/plugin-codeflare": {
       "version": "file:plugins/plugin-codeflare",
       "requires": {
-        "@guidebooks/store": "^5.1.7",
+        "@guidebooks/store": "^5.2.0",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.18",
         "@patternfly/react-core": "^4.276.6",

--- a/plugins/plugin-codeflare/package.json
+++ b/plugins/plugin-codeflare/package.json
@@ -30,7 +30,7 @@
     "@types/split2": "^3.2.1"
   },
   "dependencies": {
-    "@guidebooks/store": "^5.1.7",
+    "@guidebooks/store": "^5.2.0",
     "@logdna/tail-file": "^3.0.1",
     "@patternfly/react-charts": "^6.94.18",
     "@patternfly/react-core": "^4.276.6",

--- a/plugins/plugin-codeflare/src/controller/index.ts
+++ b/plugins/plugin-codeflare/src/controller/index.ts
@@ -24,8 +24,8 @@ import charts from "./charts"
 import events from "./events"
 import dashboard from "./dashboard"
 import description from "./description"
+import { LogsOptions, logsFlags } from "./logs"
 import { Options as AttachOptions } from "./attach"
-import { ProfileOptions, profileFlags } from "./options"
 
 function help() {
   return `Usage:
@@ -43,11 +43,9 @@ export default function registerCodeflareCommands(registrar: Registrar) {
   description(registrar)
   registrar.listen("/help", help)
 
-  registrar.listen<KResponse, ProfileOptions>(
-    "/codeflare/logs",
-    (args) => import("./logs").then((_) => _.default(args)),
-    { flags: profileFlags }
-  )
+  registrar.listen<KResponse, LogsOptions>("/codeflare/logs", (args) => import("./logs").then((_) => _.default(args)), {
+    flags: logsFlags,
+  })
 
   registrar.listen<KResponse, AttachOptions>(
     "/codeflare/attach",

--- a/plugins/plugin-codeflare/src/controller/options.ts
+++ b/plugins/plugin-codeflare/src/controller/options.ts
@@ -25,7 +25,7 @@ export type ProfileOptions = ParsedOptions & {
   verbose: string
 }
 
-export const profileFlags: CommandOptions["flags"] = {
+export const profileFlags: Required<Pick<CommandOptions, "flags">>["flags"] = {
   boolean: ["V", "verbose"],
   alias: {
     verbose: ["V"],


### PR DESCRIPTION

https://github.com/guidebooks/store/pull/576