### PR TITLE
fix: helm install may fail on linux due to base64-induced newlines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -899,9 +899,9 @@
       "license": "MIT"
     },
     "node_modules/@guidebooks/store": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-5.5.3.tgz",
-      "integrity": "sha512-V9XMFAf69iEbIv2ksD4IULEp/ENEDmpXBpvvKjj2iavjaqocGPupD1+zE44QVxyRbhwnYfAlg91lbVwqk6Cszw=="
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-5.5.4.tgz",
+      "integrity": "sha512-7ikUXDblN8+6vNVUzlkn06X1WcirDv7CicIAvbAahfWwI+qMCYgDLHsf8N88t3F66qUbf/q5nd7poPQG+IigPA=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -14478,7 +14478,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^5.5.3",
+        "@guidebooks/store": "^5.5.4",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.18",
         "@patternfly/react-core": "^4.276.6",
@@ -15088,9 +15088,9 @@
       "dev": true
     },
     "@guidebooks/store": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-5.5.3.tgz",
-      "integrity": "sha512-V9XMFAf69iEbIv2ksD4IULEp/ENEDmpXBpvvKjj2iavjaqocGPupD1+zE44QVxyRbhwnYfAlg91lbVwqk6Cszw=="
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-5.5.4.tgz",
+      "integrity": "sha512-7ikUXDblN8+6vNVUzlkn06X1WcirDv7CicIAvbAahfWwI+qMCYgDLHsf8N88t3F66qUbf/q5nd7poPQG+IigPA=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -15336,7 +15336,7 @@
     "@kui-shell/plugin-codeflare": {
       "version": "file:plugins/plugin-codeflare",
       "requires": {
-        "@guidebooks/store": "^5.5.3",
+        "@guidebooks/store": "^5.5.4",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.18",
         "@patternfly/react-core": "^4.276.6",

--- a/plugins/plugin-codeflare/package.json
+++ b/plugins/plugin-codeflare/package.json
@@ -30,7 +30,7 @@
     "@types/split2": "^3.2.1"
   },
   "dependencies": {
-    "@guidebooks/store": "^5.5.3",
+    "@guidebooks/store": "^5.5.4",
     "@logdna/tail-file": "^3.0.1",
     "@patternfly/react-charts": "^6.94.18",
     "@patternfly/react-core": "^4.276.6",


### PR DESCRIPTION
https://github.com/guidebooks/store/pull/608

That PR also updated the helm install for ray so as to avoid communicating the workdir as an env var