### PR TITLE
feat: move cpu and memory utilization to be first column

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -899,9 +899,9 @@
       "license": "MIT"
     },
     "node_modules/@guidebooks/store": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-5.5.6.tgz",
-      "integrity": "sha512-xD6NGFTOGiZzh+t6qc28hjOofCCBA0/t2Vgb8jaPQ4EvqGdretYOcdyIwZtiw4YYJ8kgf2fg2JwBY6MFQnlXEw=="
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-5.6.0.tgz",
+      "integrity": "sha512-caGy8ghwjYRFhDHW4kMOrvpIcOTqq4ckiz8d9glqSZxA9h+KxvKayb98ALhV61ughxYqEUVy3vPA00padE+CWw=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -14470,7 +14470,7 @@
     },
     "plugins/plugin-client-default": {
       "name": "@kui-shell/plugin-client",
-      "version": "2.14.2",
+      "version": "2.14.3",
       "license": "Apache-2.0"
     },
     "plugins/plugin-codeflare": {
@@ -14478,7 +14478,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^5.5.6",
+        "@guidebooks/store": "^5.6.0",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.18",
         "@patternfly/react-core": "^4.276.6",
@@ -15088,9 +15088,9 @@
       "dev": true
     },
     "@guidebooks/store": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-5.5.6.tgz",
-      "integrity": "sha512-xD6NGFTOGiZzh+t6qc28hjOofCCBA0/t2Vgb8jaPQ4EvqGdretYOcdyIwZtiw4YYJ8kgf2fg2JwBY6MFQnlXEw=="
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-5.6.0.tgz",
+      "integrity": "sha512-caGy8ghwjYRFhDHW4kMOrvpIcOTqq4ckiz8d9glqSZxA9h+KxvKayb98ALhV61ughxYqEUVy3vPA00padE+CWw=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -15336,7 +15336,7 @@
     "@kui-shell/plugin-codeflare": {
       "version": "file:plugins/plugin-codeflare",
       "requires": {
-        "@guidebooks/store": "^5.5.6",
+        "@guidebooks/store": "^5.6.0",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.18",
         "@patternfly/react-core": "^4.276.6",

--- a/plugins/plugin-codeflare/package.json
+++ b/plugins/plugin-codeflare/package.json
@@ -30,7 +30,7 @@
     "@types/split2": "^3.2.1"
   },
   "dependencies": {
-    "@guidebooks/store": "^5.5.6",
+    "@guidebooks/store": "^5.6.0",
     "@logdna/tail-file": "^3.0.1",
     "@patternfly/react-charts": "^6.94.18",
     "@patternfly/react-core": "^4.276.6",


### PR DESCRIPTION
This also should fix the warning that Winteractive is not a known option on linux/gnu awk.