### PR TITLE
fix: ray stop may never be called; ray self-destruct permissions; run id re-prompt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -899,9 +899,9 @@
       "license": "MIT"
     },
     "node_modules/@guidebooks/store": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-6.1.0.tgz",
-      "integrity": "sha512-ff0l/jEJ8i9KCULpM3UuDFRb4fuiWHofMbVfN1+SQ76R4zQB1OO2o+p/Vm9AMglqPqrQ5agAcIGXrgFRXhIBgA=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-6.1.1.tgz",
+      "integrity": "sha512-j5trxvsUAsNOSKzJtCON4Zpg94Q55yN6HmB9JtCB3gcwYPCPBbitF7OUfZzSn3yhlGGjv2VkAqGEUTbYSbT9LQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -14470,7 +14470,7 @@
     },
     "plugins/plugin-client-default": {
       "name": "@kui-shell/plugin-client",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0"
     },
     "plugins/plugin-codeflare": {
@@ -14478,7 +14478,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^6.1.0",
+        "@guidebooks/store": "^6.1.1",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.18",
         "@patternfly/react-core": "^4.276.6",
@@ -15088,9 +15088,9 @@
       "dev": true
     },
     "@guidebooks/store": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-6.1.0.tgz",
-      "integrity": "sha512-ff0l/jEJ8i9KCULpM3UuDFRb4fuiWHofMbVfN1+SQ76R4zQB1OO2o+p/Vm9AMglqPqrQ5agAcIGXrgFRXhIBgA=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-6.1.1.tgz",
+      "integrity": "sha512-j5trxvsUAsNOSKzJtCON4Zpg94Q55yN6HmB9JtCB3gcwYPCPBbitF7OUfZzSn3yhlGGjv2VkAqGEUTbYSbT9LQ=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -15336,7 +15336,7 @@
     "@kui-shell/plugin-codeflare": {
       "version": "file:plugins/plugin-codeflare",
       "requires": {
-        "@guidebooks/store": "^6.1.0",
+        "@guidebooks/store": "^6.1.1",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.18",
         "@patternfly/react-core": "^4.276.6",

--- a/plugins/plugin-codeflare/package.json
+++ b/plugins/plugin-codeflare/package.json
@@ -30,7 +30,7 @@
     "@types/split2": "^3.2.1"
   },
   "dependencies": {
-    "@guidebooks/store": "^6.1.0",
+    "@guidebooks/store": "^6.1.1",
     "@logdna/tail-file": "^3.0.1",
     "@patternfly/react-charts": "^6.94.18",
     "@patternfly/react-core": "^4.276.6",


### PR DESCRIPTION


* if ray process errors out, ray stop is never called ([70cb403](https://github.com/guidebooks/store/commit/70cb403dec49b0d018a3752539ffe5e69b6ec7d6))
* ray self-destruct may fail due to permissions ([e0f41ab](https://github.com/guidebooks/store/commit/e0f41ab9914828908c1b6a69987c2df5ef523e5c))
* user may be prompted for run id, when it is already known ([6a290e4](https://github.com/guidebooks/store/commit/6a290e49e2225245b76f7134e3d977ebd0a05386))