### PR TITLE
fix: helm workdir fails for relative paths; improved detection of ray job failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -899,9 +899,9 @@
       "license": "MIT"
     },
     "node_modules/@guidebooks/store": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-6.1.1.tgz",
-      "integrity": "sha512-j5trxvsUAsNOSKzJtCON4Zpg94Q55yN6HmB9JtCB3gcwYPCPBbitF7OUfZzSn3yhlGGjv2VkAqGEUTbYSbT9LQ=="
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-6.1.3.tgz",
+      "integrity": "sha512-qoUdXOcRd2iaWxEZoosYxz3Cx5bpoWbQYtx7ulSo1o9aFMNHITuUWi+TjaItind2xIUFrLyWfjW4igKdhFUSaQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -14478,7 +14478,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^6.1.1",
+        "@guidebooks/store": "^6.1.3",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.18",
         "@patternfly/react-core": "^4.276.6",
@@ -15088,9 +15088,9 @@
       "dev": true
     },
     "@guidebooks/store": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-6.1.1.tgz",
-      "integrity": "sha512-j5trxvsUAsNOSKzJtCON4Zpg94Q55yN6HmB9JtCB3gcwYPCPBbitF7OUfZzSn3yhlGGjv2VkAqGEUTbYSbT9LQ=="
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-6.1.3.tgz",
+      "integrity": "sha512-qoUdXOcRd2iaWxEZoosYxz3Cx5bpoWbQYtx7ulSo1o9aFMNHITuUWi+TjaItind2xIUFrLyWfjW4igKdhFUSaQ=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -15336,7 +15336,7 @@
     "@kui-shell/plugin-codeflare": {
       "version": "file:plugins/plugin-codeflare",
       "requires": {
-        "@guidebooks/store": "^6.1.1",
+        "@guidebooks/store": "^6.1.3",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.18",
         "@patternfly/react-core": "^4.276.6",

--- a/plugins/plugin-codeflare/package.json
+++ b/plugins/plugin-codeflare/package.json
@@ -30,7 +30,7 @@
     "@types/split2": "^3.2.1"
   },
   "dependencies": {
-    "@guidebooks/store": "^6.1.1",
+    "@guidebooks/store": "^6.1.3",
     "@logdna/tail-file": "^3.0.1",
     "@patternfly/react-charts": "^6.94.18",
     "@patternfly/react-core": "^4.276.6",


### PR DESCRIPTION
* helm workdir fails for relative paths ([1350e49](https://github.com/guidebooks/store/commit/1350e49674d38cc50e75522978e6bda643e768c6))
* we were looking for ERROR instead of FAILED for failed ray jobs ([8a4d332](https://github.com/guidebooks/store/commit/8a4d33268e15ec6cdd4c7cf1e6e3463facde9e3c))
* ray self-destruct should establish security context ([d6ed018](https://github.com/guidebooks/store/commit/d6ed01833b3c8ada8bb1be27abf6d36c3a74ae0a))