### PR TITLE
fix: improved kubectl and gpu streaming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -899,9 +899,9 @@
       "license": "MIT"
     },
     "node_modules/@guidebooks/store": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-6.1.3.tgz",
-      "integrity": "sha512-qoUdXOcRd2iaWxEZoosYxz3Cx5bpoWbQYtx7ulSo1o9aFMNHITuUWi+TjaItind2xIUFrLyWfjW4igKdhFUSaQ=="
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-6.1.4.tgz",
+      "integrity": "sha512-p3KqGcvSv+zxg98suwS4mGnXJhuSx1KSaqqXdJZ5WgbXpgJ0rq7PB3WV8etcyJIM8RgqwXMcCxYEQPEMJrhkvQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -14478,7 +14478,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^6.1.3",
+        "@guidebooks/store": "^6.1.4",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.18",
         "@patternfly/react-core": "^4.276.6",
@@ -15088,9 +15088,9 @@
       "dev": true
     },
     "@guidebooks/store": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-6.1.3.tgz",
-      "integrity": "sha512-qoUdXOcRd2iaWxEZoosYxz3Cx5bpoWbQYtx7ulSo1o9aFMNHITuUWi+TjaItind2xIUFrLyWfjW4igKdhFUSaQ=="
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-6.1.4.tgz",
+      "integrity": "sha512-p3KqGcvSv+zxg98suwS4mGnXJhuSx1KSaqqXdJZ5WgbXpgJ0rq7PB3WV8etcyJIM8RgqwXMcCxYEQPEMJrhkvQ=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -15336,7 +15336,7 @@
     "@kui-shell/plugin-codeflare": {
       "version": "file:plugins/plugin-codeflare",
       "requires": {
-        "@guidebooks/store": "^6.1.3",
+        "@guidebooks/store": "^6.1.4",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.18",
         "@patternfly/react-core": "^4.276.6",

--- a/plugins/plugin-codeflare/package.json
+++ b/plugins/plugin-codeflare/package.json
@@ -30,7 +30,7 @@
     "@types/split2": "^3.2.1"
   },
   "dependencies": {
-    "@guidebooks/store": "^6.1.3",
+    "@guidebooks/store": "^6.1.4",
     "@logdna/tail-file": "^3.0.1",
     "@patternfly/react-charts": "^6.94.18",
     "@patternfly/react-core": "^4.276.6",


### PR DESCRIPTION
* avoid use of -Winteractive on macos ([6a89cad](https://github.com/guidebooks/store/commit/6a89cad80665c0cafc314dbd7212914f64366209))
* gpu utilization may not be streamed out ([9925290](https://github.com/guidebooks/store/commit/9925290882ece9bbd7870d8e07046bcbfeb3d048))
* when looping kubectl events, use watch-only after first iter ([25a6511](https://github.com/guidebooks/store/commit/25a6511024e253bb3b955e2466fb4a9b508cb3ab))