### PR TITLE
feat: new console-based dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@kui-shell/plugin-bash-like": "13.1.3-dev-20230329-123301",
         "@kui-shell/plugin-client-common": "13.1.3-dev-20230329-123301",
         "@kui-shell/plugin-codeflare": "file:./plugins/plugin-codeflare",
+        "@kui-shell/plugin-codeflare-dashboard": "file:./plugins/plugin-codeflare-dashboard",
         "@kui-shell/plugin-core-support": "13.1.3-dev-20230329-123301",
         "@kui-shell/plugin-electron-components": "13.1.3-dev-20230329-123301",
         "@kui-shell/plugin-kubectl": "13.1.3-dev-20230329-123301",
@@ -427,9 +428,8 @@
     },
     "node_modules/@electron/get": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.2.tgz",
-      "integrity": "sha512-eFZVFoRXb3GFGd7Ak7W4+6jBl9wBtiZ4AaYOse97ej6mKj5tkyO0dUnUChs1IhJZtx1BENo4/p4WUTXpi6vT+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
         "env-paths": "^2.2.0",
@@ -448,9 +448,8 @@
     },
     "node_modules/@electron/get/node_modules/fs-extra": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -462,18 +461,16 @@
     },
     "node_modules/@electron/get/node_modules/jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
+      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/@electron/get/node_modules/universalify": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -881,8 +878,6 @@
     },
     "node_modules/@ewoudenberg/difflib": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@ewoudenberg/difflib/-/difflib-0.1.0.tgz",
-      "integrity": "sha512-OU5P5mJyD3OoWYMWY+yIgwvgNS9cFAU10f+DDuvtogcWQOoJIsQ4Hy2McSfUfhKjq8L0FuWVb4Rt7kgA+XK86A==",
       "dependencies": {
         "heap": ">= 0.2.0"
       }
@@ -901,9 +896,9 @@
       "license": "MIT"
     },
     "node_modules/@guidebooks/store": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.2.3.tgz",
-      "integrity": "sha512-v4AJA8JEJ4y00Nt7Y3bisdxFe7+CAFl+w28D6YgCXxmrPAcNMDEvBzn0/DGdoUvfKbdKKyreE3k4fIonXHOFKQ=="
+      "version": "7.2.8",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.2.8.tgz",
+      "integrity": "sha512-GIwJCnhQKYi0L7IJ/Dg1MJ/9ff6FdsFczaK7AVidWZnyfl3ffBjgCSjZs4IMZqdwApFu7lIDccNA4bAoPSPGPg=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -1086,15 +1081,13 @@
     },
     "node_modules/@juggle/resize-observer": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
-      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
+      "license": "Apache-2.0"
     },
     "node_modules/@kui-shell/builder": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/builder/-/builder-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-aFt/FsIrK4+3HINkrQS8L01Z21zCMWehTGj1eHJ/cL0u+MHOjvDbwyRp7oQMAzM1/1kmZsiwgCap3bJBQiqRuw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/cli": "^7.20.7",
         "@babel/core": "^7.20.12",
@@ -1127,8 +1120,7 @@
     },
     "node_modules/@kui-shell/core": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/core/-/core-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-cSGJn+qKLkHSl5jh0YY1dmD1LBTY9MuANyro+JM028CsrVVMtFvEkU4cMzhfkdh1aQz5dC/OAzsAbAwPUekMtw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "colors": "^1.4.0",
         "columnify": "^1.6.0",
@@ -1168,8 +1160,7 @@
     },
     "node_modules/@kui-shell/plugin-bash-like": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-bash-like/-/plugin-bash-like-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-JfeoeUHmHaKc4cvfONSw5uOhONDuSiCM2t+fZLkroaCTaSqKASuMtcui8IF1Zdq6PjGzo8c8y8iYYwMLKDnf+w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@kui-shell/xterm-helpers": "^2.1.0",
         "cookie": "^0.5.0",
@@ -1190,8 +1181,7 @@
     },
     "node_modules/@kui-shell/plugin-client-common": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-client-common/-/plugin-client-common-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-VyQvqhCh5EhBUYMcA8EXR/XRl4EhPKoTB46HeE9/trltWAOkpNxXvfgOE+ydVjEC6jqtA50hcy8CPq+KV1DPgQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.2.1",
         "@mdi/font": "^7.1.96",
@@ -1222,8 +1212,7 @@
     },
     "node_modules/@kui-shell/plugin-client-common/node_modules/entities": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -1235,10 +1224,13 @@
       "resolved": "plugins/plugin-codeflare",
       "link": true
     },
+    "node_modules/@kui-shell/plugin-codeflare-dashboard": {
+      "resolved": "plugins/plugin-codeflare-dashboard",
+      "link": true
+    },
     "node_modules/@kui-shell/plugin-core-support": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-core-support/-/plugin-core-support-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-pVEKpxxdRgkcuu4dV07gB/WNuKlW2vROzevcjaAu2jUYPvgyqK8X7aymQ8zZO0DrLsalfYuXCaOBznP+6wOqlg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@supercharge/promise-pool": "^2.3.2",
         "debug": "^4.3.4",
@@ -1247,8 +1239,7 @@
     },
     "node_modules/@kui-shell/plugin-electron-components": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-electron-components/-/plugin-electron-components-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-klbMV7SVqjs9mPkC43QAc83r/QgIW/JyyxvB7aMiaul1xKp3I59WWoAfJbog8Av72rG45MfeLQXeAjLkIqPPPQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-core": "^4.264.0",
         "needle": "^3.2.0"
@@ -1256,8 +1247,7 @@
     },
     "node_modules/@kui-shell/plugin-kubectl": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl/-/plugin-kubectl-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-FWyInAcyHRky2kXzqkx0iTF6tcmrvOpVD4zwSBu7xttdYO+z+YObiujvpLTi2cW2xPd8FMzWdteQLQJ6vSyIEg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@kui-shell/jsonpath": "^1.1.1",
         "@kui-shell/plugin-kubectl-core": "^13.1.3-dev-20230329-123301",
@@ -1279,8 +1269,7 @@
     },
     "node_modules/@kui-shell/plugin-kubectl-core": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl-core/-/plugin-kubectl-core-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-woE3/yldVRGfLwdAoKcAlOem7NbTtbMcgwak0XKJwh1He1E6JFsL6OoJzj6zFVWrIn334Xfsd5XyAad1dzwjlg=="
+      "license": "Apache-2.0"
     },
     "node_modules/@kui-shell/plugin-kubectl/node_modules/fs-extra": {
       "version": "11.1.0",
@@ -1323,8 +1312,7 @@
     },
     "node_modules/@kui-shell/plugin-madwizard": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-madwizard/-/plugin-madwizard-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-IZDSPW+4B3cB54DENBOYYqK4ZNtPtsNC+8wAaEAejLnxfGWTWIlih2PvApa+zusIp+r7OvvijeYJzWWY2O1guQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@patternfly/react-core": "^4.267.6",
         "allotment": "^1.18.1",
@@ -1351,20 +1339,17 @@
     },
     "node_modules/@kui-shell/plugin-patternfly4-themes": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-patternfly4-themes/-/plugin-patternfly4-themes-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-SguVXC/rHGYwO0MJbM1LZJqbSaFFtQzVuLDW12wjd2QUPqW4gDHnfsyAy3PVJEsGQLMagIMFyyLE4xa7/vnvfQ=="
+      "license": "Apache-2.0"
     },
     "node_modules/@kui-shell/plugin-proxy-support": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-proxy-support/-/plugin-proxy-support-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-18ky5/TjIRmymhGIYxuCoxyab20/zblIhLVD5eJxqF1sMheMJ+EVoMTiH7zi4IaCVeBTyoNW7T2D822pA6rvvw=="
+      "license": "Apache-2.0"
     },
     "node_modules/@kui-shell/proxy": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/proxy/-/proxy-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-IcgOw9ztpbZyvcj89hJBYwALPz9tPM2BWQNDYhKYvy87yH8aRPWFOfxlZgO9k6GgbIulmZrwxWAlR0ak7cg7WQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "bin": {
         "kui-build-docker-with-proxy": "build-docker.sh",
         "kui-build-proxy": "build.sh",
@@ -1374,9 +1359,8 @@
     },
     "node_modules/@kui-shell/react": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/react/-/react-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-a6NVtUBIeZhKTvnhYUI7KBl3kh6HCoygtmZByVivIMJD2c3FzCIGOoahGM32TycBckiPk7N2bXySF4+xHsVhLA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -1384,9 +1368,8 @@
     },
     "node_modules/@kui-shell/webpack": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/webpack/-/webpack-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-bFR0rVRGoRTIHyQJ1Xg7bkSh2LjnGwxY6vidvd6Rc+ogXa+IzXAEoVhThs+JQ12Fs1CMyRlzpv/EtDW4X6rCvA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "assert": "^2.0.0",
         "browserify-zlib": "^0.2.0",
@@ -1442,14 +1425,12 @@
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
-      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@logdna/tail-file": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@logdna/tail-file/-/tail-file-3.0.1.tgz",
-      "integrity": "sha512-c7Ve4yYM/aHzYb9njTP/mdZtw4MAD+On/1I1XhvfrWUHud2XZ1KyhKnWRNXfbJHuHMtcL2GIjQ8V4a/yb4hygw==",
+      "license": "SEE LICENSE IN LICENSE",
       "engines": {
         "node": ">= 12"
       }
@@ -1516,8 +1497,7 @@
     },
     "node_modules/@npmcli/fs": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.0.tgz",
-      "integrity": "sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==",
+      "license": "ISC",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -1527,8 +1507,7 @@
     },
     "node_modules/@npmcli/fs/node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -1538,8 +1517,7 @@
     },
     "node_modules/@npmcli/fs/node_modules/semver": {
       "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1552,8 +1530,7 @@
     },
     "node_modules/@npmcli/fs/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "license": "ISC"
     },
     "node_modules/@npmcli/move-file": {
       "version": "2.0.1",
@@ -1569,8 +1546,7 @@
     },
     "node_modules/@patternfly/react-charts": {
       "version": "6.94.18",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.94.18.tgz",
-      "integrity": "sha512-56WxnZYC3blRX41mW67JaPxJ3YhXViLvwGpEsZrYCccla/rTV8JgKK0gjHnqtzPQiVBfpn+3ewOyNCOR5uRoSw==",
+      "license": "MIT",
       "dependencies": {
         "@patternfly/react-styles": "^4.92.6",
         "@patternfly/react-tokens": "^4.94.6",
@@ -1601,8 +1577,7 @@
     },
     "node_modules/@patternfly/react-core": {
       "version": "4.276.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.276.6.tgz",
-      "integrity": "sha512-G0K+378jf9jw9g+hCAoKnsAe/UGTRspqPeuAYypF2FgNr+dC7dUpc7/VkNhZBVqSJzUWVEK8NyXcqkfi0IemIg==",
+      "license": "MIT",
       "dependencies": {
         "@patternfly/react-icons": "^4.93.6",
         "@patternfly/react-styles": "^4.92.6",
@@ -1619,8 +1594,7 @@
     },
     "node_modules/@patternfly/react-icons": {
       "version": "4.93.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.93.6.tgz",
-      "integrity": "sha512-ZrXegc/81oiuTIeWvoHb3nG/eZODbB4rYmekBEsrbiysyO7m/sUFoi/RLvgFINrRoh6YCJqL5fj06Jg6d7jX1g==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18",
         "react-dom": "^16.8 || ^17 || ^18"
@@ -1628,13 +1602,11 @@
     },
     "node_modules/@patternfly/react-styles": {
       "version": "4.92.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.92.6.tgz",
-      "integrity": "sha512-b8uQdEReMyeoMzjpMri845QxqtupY/tIFFYfVeKoB2neno8gkcW1RvDdDe62LF88q45OktCwAe/8A99ker10Iw=="
+      "license": "MIT"
     },
     "node_modules/@patternfly/react-table": {
       "version": "4.112.39",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.112.39.tgz",
-      "integrity": "sha512-U+hOMgYlbghGH4M5MX+qt0GkVi/ocrGnxDnm11YiS3CtEGsd6Rr0NeqMmk0uoR46Od4Pr5tKuXxZhPP32sCL/w==",
+      "license": "MIT",
       "dependencies": {
         "@patternfly/react-core": "^4.276.6",
         "@patternfly/react-icons": "^4.93.6",
@@ -1650,14 +1622,12 @@
     },
     "node_modules/@patternfly/react-tokens": {
       "version": "4.94.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.94.6.tgz",
-      "integrity": "sha512-tm7C6nat+uKMr1hrapis7hS3rN9cr41tpcCKhx6cod6FLU8KwF2Yt5KUxakhIOCEcE/M/EhXhAw/qejp8w0r7Q=="
+      "license": "MIT"
     },
     "node_modules/@playwright/test": {
       "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.0.tgz",
-      "integrity": "sha512-Ys5s/06Dg9g3zAIdCIb/UOBYim3U7Zjb3DvC6XBtnRmnglH5O47iwYzmtxXu9fhSyzI2Jn28apkXIOD81GgCdw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "*",
         "playwright-core": "1.31.0"
@@ -1723,9 +1693,8 @@
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
-      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -1733,9 +1702,8 @@
     },
     "node_modules/@types/bonjour": {
       "version": "3.5.10",
-      "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.10.tgz",
-      "integrity": "sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1753,18 +1721,16 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.35",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
-      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/connect-history-api-fallback": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz",
-      "integrity": "sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
@@ -1844,9 +1810,8 @@
     },
     "node_modules/@types/express": {
       "version": "4.17.17",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
-      "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -1856,9 +1821,8 @@
     },
     "node_modules/@types/express-serve-static-core": {
       "version": "4.17.33",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
-      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -1867,8 +1831,7 @@
     },
     "node_modules/@types/extend": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw=="
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "2.3.4",
@@ -1889,9 +1852,8 @@
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.10",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.10.tgz",
-      "integrity": "sha512-Qs5aULi+zV1bwKAg5z1PWnDXWmsn+LxIvUGv6E2+OOMYhclZMO+OXd9pYVf2gLykf2I7IV2u7oTHwChPNsvJ7g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1938,9 +1900,8 @@
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
-      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "0.7.31",
@@ -1948,9 +1909,8 @@
     },
     "node_modules/@types/needle": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/needle/-/needle-3.2.0.tgz",
-      "integrity": "sha512-6XzvzEyJ2ozFNfPajFmqH9JOt0Hp+9TawaYpJT59iIP/zR0U37cfWCRwosyIeEBBZBi021Osq4jGAD3AOju5fg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1969,20 +1929,17 @@
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.0.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
-      "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
+      "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1991,9 +1948,8 @@
     },
     "node_modules/@types/react-dom": {
       "version": "18.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
-      "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/react": "*"
       }
@@ -2008,9 +1964,8 @@
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
@@ -2018,24 +1973,21 @@
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/serve-index": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.1.tgz",
-      "integrity": "sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/express": "*"
       }
     },
     "node_modules/@types/serve-static": {
       "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.1.tgz",
-      "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/mime": "*",
         "@types/node": "*"
@@ -2043,9 +1995,8 @@
     },
     "node_modules/@types/sockjs": {
       "version": "0.3.33",
-      "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.33.tgz",
-      "integrity": "sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2064,9 +2015,8 @@
     },
     "node_modules/@types/ws": {
       "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
-      "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2086,19 +2036,22 @@
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
+    "node_modules/@types/yoga-layout": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz",
+      "integrity": "sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw=="
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.53.0.tgz",
-      "integrity": "sha512-alFpFWNucPLdUOySmXCJpzr6HKC3bu7XooShWM+3w/EL6J2HIoB2PFxpLnq4JauWVk6DiVeNKzQlFEaE+X9sGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.53.0",
         "@typescript-eslint/type-utils": "5.53.0",
@@ -2160,9 +2113,8 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.53.0.tgz",
-      "integrity": "sha512-MKBw9i0DLYlmdOb3Oq/526+al20AJZpANdT6Ct9ffxcV8nKCHz63t/S0IhlTFNsBIHJv+GY5SFJ0XfqVeydQrQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.53.0",
         "@typescript-eslint/types": "5.53.0",
@@ -2187,9 +2139,8 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.53.0.tgz",
-      "integrity": "sha512-Opy3dqNsp/9kBBeCPhkCNR7fmdSQqA+47r21hr9a14Bx0xnkElEQmhoHga+VoaoQ6uDHjDKmQPIYcUcKJifS7w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "5.53.0",
         "@typescript-eslint/visitor-keys": "5.53.0"
@@ -2204,9 +2155,8 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.53.0.tgz",
-      "integrity": "sha512-HO2hh0fmtqNLzTAme/KnND5uFNwbsdYhCZghK2SoxGp3Ifn2emv+hi0PBUjzzSh0dstUIFqOj3bp0AwQlK4OWw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/typescript-estree": "5.53.0",
         "@typescript-eslint/utils": "5.53.0",
@@ -2231,9 +2181,8 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.53.0.tgz",
-      "integrity": "sha512-5kcDL9ZUIP756K6+QOAfPkigJmCPHcLN7Zjdz76lQWWDdzfOhZDTj1irs6gPBKiXx5/6O3L0+AvupAut3z7D2A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -2244,9 +2193,8 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.53.0.tgz",
-      "integrity": "sha512-eKmipH7QyScpHSkhbptBBYh9v8FxtngLquq292YTEQ1pxVs39yFBlLC1xeIZcPPz1RWGqb7YgERJRGkjw8ZV7w==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/types": "5.53.0",
         "@typescript-eslint/visitor-keys": "5.53.0",
@@ -2271,9 +2219,8 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -2283,9 +2230,8 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2298,15 +2244,13 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.53.0.tgz",
-      "integrity": "sha512-VUOOtPv27UNWLxFwQK/8+7kvxVC+hPHNsJjzlJyotlaHjLSIgOCKj9I0DBUjwOOA64qjBwx5afAPjksqOxMO0g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
@@ -2330,9 +2274,8 @@
     },
     "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -2342,9 +2285,8 @@
     },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
       "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2357,15 +2299,13 @@
     },
     "node_modules/@typescript-eslint/utils/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.53.0.tgz",
-      "integrity": "sha512-JqNLnX3leaHFZEN0gCh81sIvgrp/2GOACZNgO4+Tkf64u51kTpAyWFOY8XHx8XuXr3N2C9zgPPHtcpMg6z1g0w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "5.53.0",
         "eslint-visitor-keys": "^3.3.0"
@@ -2555,9 +2495,8 @@
     },
     "node_modules/accepts": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -2683,8 +2622,7 @@
     },
     "node_modules/allotment": {
       "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/allotment/-/allotment-1.18.1.tgz",
-      "integrity": "sha512-ZhmpHoSvxHyPT5XjzTHeCBjzCMIFn1aGdNAzBCZhj1CcRMp31CaJCi+lfweoOLDbbjJqbFZqUk3xf+p7Mb0x5A==",
+      "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.0",
         "eventemitter3": "^5.0.0",
@@ -2700,8 +2638,7 @@
     },
     "node_modules/allotment/node_modules/eventemitter3": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.0.tgz",
-      "integrity": "sha512-riuVbElZZNXLeLEoprfNYoDSwTBRR44X3mnhdI1YcnENpWTCsTTVZ2zFuqQcpoyqPQIUXdiPEU0ECAq0KQRaHg=="
+      "license": "MIT"
     },
     "node_modules/anser": {
       "version": "2.1.1",
@@ -2716,7 +2653,6 @@
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.21.3"
@@ -2730,12 +2666,11 @@
     },
     "node_modules/ansi-html-community": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
-      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
       "dev": true,
       "engines": [
         "node >= 0.8.0"
       ],
+      "license": "Apache-2.0",
       "bin": {
         "ansi-html": "bin/ansi-html"
       }
@@ -2795,9 +2730,8 @@
     },
     "node_modules/array-flatten": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
-      "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -2808,8 +2742,7 @@
     },
     "node_modules/asciinema-player": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/asciinema-player/-/asciinema-player-3.1.0.tgz",
-      "integrity": "sha512-O36+vQOreHW2w9Sao7AbHY4o3RJW7AxtVGtQdb74QkKZmaY8VzQJ3u36PTzltqlybJIpwXY9yK/PdVVmgmTEpg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "solid-js": "^1.3.0"
@@ -2844,7 +2777,6 @@
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2858,6 +2790,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/auto-bind": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
+      "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -2916,9 +2859,8 @@
     },
     "node_modules/batch": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/big.js": {
       "version": "5.2.2",
@@ -2974,9 +2916,8 @@
     },
     "node_modules/body-parser": {
       "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.4",
@@ -2998,36 +2939,32 @@
     },
     "node_modules/body-parser/node_modules/bytes": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/body-parser/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/body-parser/node_modules/depd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/body-parser/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -3037,15 +2974,13 @@
     },
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bonjour-service": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.1.tgz",
-      "integrity": "sha512-Z/5lQRMOG9k7W+FkeGTNjh7htqn/2LMnfOvBZ8pynNZCM9MwkQkI3zeI4oz09uWdcgmgHugVvBqxGg4VQJ5PCg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-flatten": "^2.1.2",
         "dns-equal": "^1.0.0",
@@ -3060,9 +2995,8 @@
     },
     "node_modules/boolean": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/brace-expansion": {
@@ -3227,9 +3161,8 @@
     },
     "node_modules/bytes": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -3243,8 +3176,7 @@
     },
     "node_modules/cacache": {
       "version": "17.0.4",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.0.4.tgz",
-      "integrity": "sha512-Z/nL3gU+zTUjz5pCA5vVjYM8pmaw2kxM7JEiE0fv3w77Wj+sFbi70CrBruUWH0uNcEdvLDixFpgA2JM4F4DBjA==",
+      "license": "ISC",
       "dependencies": {
         "@npmcli/fs": "^3.1.0",
         "fs-minipass": "^3.0.0",
@@ -3266,16 +3198,14 @@
     },
     "node_modules/cacache/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/cacache/node_modules/glob": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3292,16 +3222,14 @@
     },
     "node_modules/cacache/node_modules/lru-cache": {
       "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-      "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/cacache/node_modules/minimatch": {
       "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -3505,8 +3433,7 @@
     },
     "node_modules/classnames": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+      "license": "MIT"
     },
     "node_modules/clean-css": {
       "version": "5.3.1",
@@ -3526,9 +3453,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^3.1.0"
@@ -3628,6 +3565,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/code-excerpt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-3.0.0.tgz",
+      "integrity": "sha512-VHNTVhd7KsLGOqfX3SyeO8RyYPMp1GJOg194VITk04WMYCv4plV68YWe6TJZxd9MhobjtpMRnVky01gqZsalaw==",
+      "dependencies": {
+        "convert-to-spaces": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "dev": true,
@@ -3699,9 +3647,8 @@
     },
     "node_modules/compressible": {
       "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
-      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mime-db": ">= 1.43.0 < 2"
       },
@@ -3711,9 +3658,8 @@
     },
     "node_modules/compression": {
       "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
-      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.5",
         "bytes": "3.0.0",
@@ -3748,24 +3694,21 @@
     },
     "node_modules/compression/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/compression/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/compression/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3877,9 +3820,8 @@
     },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
-      "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
@@ -3896,9 +3838,8 @@
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -3908,9 +3849,8 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3919,6 +3859,14 @@
       "version": "1.9.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/convert-to-spaces": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
+      "integrity": "sha512-cj09EBuObp9gZNQCzc7hByQyrs6jVGE+o9kSJmeUoj+GiPiJvi5LYqEH/Hmme4+MTLHM+Ejtq+FChpjjEnsPdQ==",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/cookie": {
       "version": "0.5.0",
@@ -3929,9 +3877,8 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/copy-webpack-plugin": {
       "version": "11.0.0",
@@ -4003,9 +3950,8 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
@@ -4525,9 +4471,8 @@
     },
     "node_modules/default-gateway": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
-      "integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "execa": "^5.0.0"
       },
@@ -4537,9 +4482,8 @@
     },
     "node_modules/default-gateway/node_modules/execa": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.0",
@@ -4560,9 +4504,8 @@
     },
     "node_modules/default-gateway/node_modules/get-stream": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -4572,18 +4515,16 @@
     },
     "node_modules/default-gateway/node_modules/human-signals": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
       }
     },
     "node_modules/default-gateway/node_modules/is-stream": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -4593,18 +4534,16 @@
     },
     "node_modules/default-gateway/node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/default-gateway/node_modules/npm-run-path": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
       },
@@ -4614,9 +4553,8 @@
     },
     "node_modules/default-gateway/node_modules/onetime": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -4629,9 +4567,8 @@
     },
     "node_modules/default-gateway/node_modules/strip-final-newline": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -4717,9 +4654,8 @@
     },
     "node_modules/destroy": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
@@ -4772,15 +4708,13 @@
     },
     "node_modules/dns-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-      "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dns-packet": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.5.0.tgz",
-      "integrity": "sha512-USawdAUzRkV6xrqTjiAEp6M9YagZEzWcSUaZTcIFAiyQWW1SoI6KyId8y2+/71wbgHKQAKd+iupLv4YvEwYWvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@leichtgewicht/ip-codec": "^2.0.1"
       },
@@ -4873,8 +4807,6 @@
     },
     "node_modules/dreamopt": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.8.0.tgz",
-      "integrity": "sha512-vyJTp8+mC+G+5dfgsY+r3ckxlz+QMX40VjPQsZc5gxVAxLmi64TBoVkP54A/pRAXMXsbu2GMMBrZPxNv23waMg==",
       "dependencies": {
         "wordwrap": ">=0.0.2"
       },
@@ -4889,16 +4821,14 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron": {
       "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-22.3.0.tgz",
-      "integrity": "sha512-RYraLSk4KitmdIuA1jZzOrzGC9g3u6vxDR5VR6K6jFLw295LOkWiuUorbuFrJ/yftRQBr8+F7S1bqak/Po5xlw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^16.11.26",
@@ -4917,9 +4847,8 @@
     },
     "node_modules/electron/node_modules/@types/node": {
       "version": "16.18.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
-      "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -4954,8 +4883,7 @@
     },
     "node_modules/emoticon": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/emoticon/-/emoticon-4.0.1.tgz",
-      "integrity": "sha512-dqx7eA9YaqyvYtUhJwT4rC1HIp82j5ybS1/vQ42ur+jBe17dJMwZE4+gvL1XadSFfxaPFFGt3Xsw+Y8akThDlw==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -4963,9 +4891,8 @@
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -5000,7 +4927,7 @@
     "node_modules/enquirer": {
       "version": "2.3.7",
       "resolved": "git+https://git@github.com/starpit/enquirer.git#d4dec9ed10d498efeb401eb99517d64f345056d9",
-      "integrity": "sha512-NkTuQL03Tz3xnBFqrPfTuu5q5ee80hS/77ercSgh4NhFnguFqtJIzUOBJBBFyv15nd6stELeeJ5i+esED5g6fQ==",
+      "integrity": "sha512-IzfZT91hHuQLPdfgGvwaQrAD9GDTgO/8qxNs1mrAaAZcYsAlgl8UMLXSZtqfw+0ATErcBH0RAqEVYqOgDG1Zzw==",
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.1",
@@ -5047,9 +4974,8 @@
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/es6-object-assign": {
@@ -5066,9 +4992,8 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -5153,9 +5078,8 @@
     },
     "node_modules/eslint": {
       "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.34.0.tgz",
-      "integrity": "sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint/eslintrc": "^1.4.1",
         "@humanwhocodes/config-array": "^0.11.8",
@@ -5460,18 +5384,16 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -5524,14 +5446,12 @@
     },
     "node_modules/expand-home-dir": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/expand-home-dir/-/expand-home-dir-0.0.3.tgz",
-      "integrity": "sha512-f4P4+coDbYiQPui6LHV4DQFEvzINm9de9w7f+4kz5aGM5kcoe8zc7hnrOLAO7+NAlCLJtNhepUqkLDMKRPQoLA=="
+      "license": "BSD"
     },
     "node_modules/express": {
       "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -5571,33 +5491,29 @@
     },
     "node_modules/express/node_modules/array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/express/node_modules/depd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/express/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -5605,9 +5521,8 @@
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -5677,9 +5592,8 @@
     },
     "node_modules/faye-websocket": {
       "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
-      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "websocket-driver": ">=0.5.1"
       },
@@ -5689,17 +5603,15 @@
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
       }
     },
     "node_modules/figures": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
-      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
+      "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^5.0.0",
         "is-unicode-supported": "^1.2.0"
@@ -5713,8 +5625,7 @@
     },
     "node_modules/figures/node_modules/escape-string-regexp": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -5791,9 +5702,8 @@
     },
     "node_modules/finalhandler": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -5809,18 +5719,16 @@
     },
     "node_modules/finalhandler/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -5863,8 +5771,6 @@
     },
     "node_modules/follow-redirects": {
       "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "dev": true,
       "funding": [
         {
@@ -5872,6 +5778,7 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -5897,42 +5804,37 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/fresh": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/front-matter": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-4.0.2.tgz",
-      "integrity": "sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==",
+      "license": "MIT",
       "dependencies": {
         "js-yaml": "^3.13.1"
       }
     },
     "node_modules/front-matter/node_modules/argparse": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/front-matter/node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -5943,8 +5845,7 @@
     },
     "node_modules/front-matter/node_modules/js-yaml": {
       "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -5955,8 +5856,7 @@
     },
     "node_modules/front-matter/node_modules/sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -5973,8 +5873,7 @@
     },
     "node_modules/fs-minipass": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.1.tgz",
-      "integrity": "sha512-MhaJDcFRTuLidHrIttu0RDGyyXs/IYHVmlcxfLAEFIWjc1vdLAkdwT7Ace2u7DbitWC0toKMl5eJZRYNVreIMw==",
+      "license": "ISC",
       "dependencies": {
         "minipass": "^4.0.0"
       },
@@ -5984,9 +5883,8 @@
     },
     "node_modules/fs-monkey": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
-      "integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==",
-      "dev": true
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/fs-readdir-recursive": {
       "version": "1.1.0",
@@ -6136,9 +6034,8 @@
     },
     "node_modules/global-agent": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
-      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
@@ -6154,9 +6051,8 @@
     },
     "node_modules/global-agent/node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
@@ -6167,9 +6063,8 @@
     },
     "node_modules/global-agent/node_modules/semver": {
       "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
+      "license": "ISC",
       "optional": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6183,9 +6078,8 @@
     },
     "node_modules/global-agent/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
+      "license": "ISC",
       "optional": true
     },
     "node_modules/globals": {
@@ -6198,9 +6092,8 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
-      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "define-properties": "^1.1.3"
@@ -6214,8 +6107,7 @@
     },
     "node_modules/globby": {
       "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -6277,9 +6169,8 @@
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
-      "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -6388,8 +6279,7 @@
     },
     "node_modules/hast-util-embedded": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-2.0.1.tgz",
-      "integrity": "sha512-QUdSOP1/o+/TxXtpPFXR2mUg2P+ySrmlX7QjwHZCXqMFyYk7YmcGSvqRW+4XgXAoHifdE1t2PwFaQK33TqVjSw==",
+      "license": "MIT",
       "dependencies": {
         "hast-util-is-element": "^2.0.0"
       },
@@ -6437,8 +6327,7 @@
     },
     "node_modules/hast-util-is-body-ok-link": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-2.0.0.tgz",
-      "integrity": "sha512-S58hCexyKdD31vMsErvgLfflW6vYWo/ixRLPJTtkOvLld24vyI8vmYmkgLA5LG3la2ME7nm7dLGdm48gfLRBfw==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^2.0.0",
         "hast-util-has-property": "^2.0.0",
@@ -6451,8 +6340,7 @@
     },
     "node_modules/hast-util-is-element": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.3.tgz",
-      "integrity": "sha512-O1bKah6mhgEq2WtVMk+Ta5K7pPMqsBBlmzysLdcwKVrqzZQ0CHqUPiIVspNhAG1rvxpvJjtGee17XfauZYKqVA==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^2.0.0",
         "@types/unist": "^2.0.0"
@@ -6475,8 +6363,7 @@
     },
     "node_modules/hast-util-phrasing": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-2.0.2.tgz",
-      "integrity": "sha512-yGkCfPkkfCyiLfK6KEl/orMDr/zgCnq/NaO9HfULx6/Zga5fso5eqQA5Ov/JZVqACygvw9shRYWgXNcG2ilo7w==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^2.0.0",
         "hast-util-embedded": "^2.0.0",
@@ -6512,8 +6399,7 @@
     },
     "node_modules/hast-util-to-html": {
       "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-8.0.4.tgz",
-      "integrity": "sha512-4tpQTUOr9BMjtYyNlt0P50mH7xj0Ks2xpo8M943Vykljf99HW6EzulIoJP1N3eKOSScEHzyzi9dm7/cn0RfGwA==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^2.0.0",
         "@types/unist": "^2.0.0",
@@ -6534,8 +6420,7 @@
     },
     "node_modules/hast-util-to-mdast": {
       "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-9.0.0.tgz",
-      "integrity": "sha512-7Pl4mWA3JCSHx0s3A1CgJaFirkISDUJsu+DeJd/cHUAlVDgs1sITzg9HZAidSf9LUE7kl8Hf2ZJr1HZTfhV/Yw==",
+      "license": "MIT",
       "dependencies": {
         "@types/extend": "^3.0.0",
         "@types/hast": "^2.0.0",
@@ -6587,8 +6472,7 @@
     },
     "node_modules/hast-util-to-text": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-3.1.2.tgz",
-      "integrity": "sha512-tcllLfp23dJJ+ju5wCCZHVpzsQQ43+moJbqVX3jNWPB7z/KFC4FyZD6R7y94cHL6MQ33YtMZL8Z0aIXXI4XFTw==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^2.0.0",
         "@types/unist": "^2.0.0",
@@ -6633,8 +6517,7 @@
     },
     "node_modules/heap": {
       "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
-      "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg=="
+      "license": "MIT"
     },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
@@ -6655,9 +6538,8 @@
     },
     "node_modules/hpack.js": {
       "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-      "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
         "obuf": "^1.0.0",
@@ -6667,9 +6549,8 @@
     },
     "node_modules/hpack.js/node_modules/readable-stream": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -6682,24 +6563,21 @@
     },
     "node_modules/hpack.js/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hpack.js/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/html-entities": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
-      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-minifier-terser": {
       "version": "6.1.0",
@@ -6779,20 +6657,17 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+      "license": "BSD-2-Clause"
     },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-      "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -6806,24 +6681,21 @@
     },
     "node_modules/http-errors/node_modules/depd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/http-parser-js": {
       "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
-      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-proxy": {
       "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -6847,9 +6719,8 @@
     },
     "node_modules/http-proxy-middleware": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",
@@ -6871,9 +6742,8 @@
     },
     "node_modules/http-proxy-middleware/node_modules/is-plain-obj": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -6990,9 +6860,8 @@
     },
     "node_modules/immutable": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
-      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -7058,14 +6927,222 @@
       "version": "2.0.4",
       "license": "ISC"
     },
+    "node_modules/ink": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-3.2.0.tgz",
+      "integrity": "sha512-firNp1q3xxTzoItj/eOOSZQnYSlyrWks5llCTVX37nJ59K3eXbQ8PtzCguqo8YI19EELo5QxaKnJd4VxzhU8tg==",
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "auto-bind": "4.0.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.0",
+        "cli-cursor": "^3.1.0",
+        "cli-truncate": "^2.1.0",
+        "code-excerpt": "^3.0.0",
+        "indent-string": "^4.0.0",
+        "is-ci": "^2.0.0",
+        "lodash": "^4.17.20",
+        "patch-console": "^1.0.0",
+        "react-devtools-core": "^4.19.1",
+        "react-reconciler": "^0.26.2",
+        "scheduler": "^0.20.2",
+        "signal-exit": "^3.0.2",
+        "slice-ansi": "^3.0.0",
+        "stack-utils": "^2.0.2",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.12.0",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^6.2.0",
+        "ws": "^7.5.5",
+        "yoga-layout-prebuilt": "^1.9.6"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ink/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/ink/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/ink/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ink/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ink/node_modules/react-reconciler": {
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.26.2.tgz",
+      "integrity": "sha512-nK6kgY28HwrMNwDnMui3dvm3rCFjZrcGiuwLc5COUipBK5hWHLOxMJhSnSomirqWwjPBJKV1QcbkI0VJr7Gl1Q==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.2"
+      }
+    },
+    "node_modules/ink/node_modules/scheduler": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "node_modules/ink/node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ink/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ink/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ink/node_modules/type-fest": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
+      "integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inline-style-parser": {
       "version": "0.1.1",
       "license": "MIT"
     },
     "node_modules/install": {
       "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/install/-/install-0.13.0.tgz",
-      "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
@@ -7090,9 +7167,8 @@
     },
     "node_modules/ipaddr.js": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
-      "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
@@ -7173,6 +7249,22 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dependencies": {
+        "ci-info": "^2.0.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/is-ci/node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
     },
     "node_modules/is-core-module": {
       "version": "2.11.0",
@@ -7349,8 +7441,7 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -7370,9 +7461,8 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -7550,8 +7640,7 @@
     },
     "node_modules/json-diff": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-1.0.3.tgz",
-      "integrity": "sha512-W0yk/xzjz7bag9v9eS4qthvPG4O07uxNeXwirhvcOqmX4w8HLtB/Pw76o5Z7Pblwvf4vpCi4+iHOlHDnmav/rA==",
+      "license": "MIT",
       "dependencies": {
         "@ewoudenberg/difflib": "0.1.0",
         "colors": "^1.4.0",
@@ -7634,18 +7723,16 @@
     },
     "node_modules/klona": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
-      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/launch-editor": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.0.tgz",
-      "integrity": "sha512-JpDCcQnyAAzZZaZ7vEiSqL690w7dAEyLao+KC96zBplnYbJS7TYNjvM3M7y3dGz+v7aIsJk3hllWuc0kWAjyRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "picocolors": "^1.0.0",
         "shell-quote": "^1.7.3"
@@ -7673,9 +7760,8 @@
     },
     "node_modules/lint-staged": {
       "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.1.2.tgz",
-      "integrity": "sha512-K9b4FPbWkpnupvK3WXZLbgu9pchUJ6N7TtVZjbaPsoizkqFUDkUReUL25xdrCljJs7uLUF3tZ7nVPeo/6lp+6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cli-truncate": "^3.1.0",
         "colorette": "^2.0.19",
@@ -7866,18 +7952,15 @@
     },
     "node_modules/lodash.clamp": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.clamp/-/lodash.clamp-4.0.3.tgz",
-      "integrity": "sha512-HvzRFWjtcguTW7yd8NJBshuNaCa8aqNFtnswdT7f/cMd/1YKy5Zzoq4W/Oxvnx9l7aeY258uSdDfM793+eLsVg=="
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+      "license": "MIT"
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+      "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -8147,13 +8230,12 @@
     },
     "node_modules/madwizard": {
       "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-7.0.4.tgz",
-      "integrity": "sha512-9ri2Wf0sr5FfK7wvugSSXwUO8ueO2aIaglRAUsFn+wMGrvXtSkwkjLWRGYq6KxiElDFgU/6IuxUW7SyFabshYQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.2.0",
         "columnify": "^1.6.0",
         "debug": "^4.3.4",
-        "enquirer": "git+https://git@github.com/starpit/enquirer.git#d4dec9ed10d498efeb401eb99517d64f345056d9",
+        "enquirer": "https://git@github.com/starpit/enquirer#d4dec9ed10d498efeb401eb99517d64f345056d9",
         "env-paths": "^2.2.1",
         "escalade": "^3.1.1",
         "expand-home-dir": "^0.0.3",
@@ -8191,8 +8273,7 @@
     },
     "node_modules/madwizard/node_modules/chalk": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -8202,8 +8283,7 @@
     },
     "node_modules/madwizard/node_modules/cli-cursor": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
       "dependencies": {
         "restore-cursor": "^4.0.0"
       },
@@ -8216,8 +8296,7 @@
     },
     "node_modules/madwizard/node_modules/entities": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -8227,8 +8306,7 @@
     },
     "node_modules/madwizard/node_modules/hast-util-raw": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-8.0.0.tgz",
-      "integrity": "sha512-bKbaUxMNLjZMMowgcrc4l3aQSPiMLiceZD+mp+AKF8Si0mtyR2DYVdxzS2XBxXYDeW/VvfZy40lNxHRiY6MMTg==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^2.0.0",
         "extend": "^3.0.0",
@@ -8250,8 +8328,7 @@
     },
     "node_modules/madwizard/node_modules/is-interactive": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -8261,8 +8338,7 @@
     },
     "node_modules/madwizard/node_modules/log-symbols": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
-      "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.0.0",
         "is-unicode-supported": "^1.1.0"
@@ -8276,16 +8352,14 @@
     },
     "node_modules/madwizard/node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/madwizard/node_modules/onetime": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -8298,8 +8372,7 @@
     },
     "node_modules/madwizard/node_modules/ora": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-6.2.0.tgz",
-      "integrity": "sha512-c1qb/1rdE+EFDYiLXh10VY459uMh7DN9zlgd8mZJLoeiPpYllN8eAOiih2Rkah5ywxRm5tHN5C9zPheDq8d1MA==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.0.0",
         "cli-cursor": "^4.0.0",
@@ -8320,8 +8393,7 @@
     },
     "node_modules/madwizard/node_modules/parse5": {
       "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "license": "MIT",
       "dependencies": {
         "entities": "^4.4.0"
       },
@@ -8331,8 +8403,7 @@
     },
     "node_modules/madwizard/node_modules/restore-cursor": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -8346,8 +8417,7 @@
     },
     "node_modules/madwizard/node_modules/strip-ansi": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -8380,8 +8450,7 @@
     },
     "node_modules/make-fetch-happen": {
       "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-11.0.3.tgz",
-      "integrity": "sha512-oPLh5m10lRNNZDjJ2kP8UpboUx2uFXVaVweVe/lWut4iHWcQEmfqSVJt2ihZsFI8HbpwyyocaXbCAWf0g1ukIA==",
+      "license": "ISC",
       "dependencies": {
         "agentkeepalive": "^4.2.1",
         "cacache": "^17.0.0",
@@ -8405,8 +8474,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/lru-cache": {
       "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-      "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -8421,9 +8489,8 @@
     },
     "node_modules/matcher": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0"
@@ -8434,9 +8501,8 @@
     },
     "node_modules/matcher/node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=10"
@@ -8486,8 +8552,7 @@
     },
     "node_modules/mdast-util-find-and-replace": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
-      "integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
+      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "escape-string-regexp": "^5.0.0",
@@ -8707,18 +8772,16 @@
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/memfs": {
       "version": "3.4.13",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.13.tgz",
-      "integrity": "sha512-omTM41g3Skpvx5dSYeZIbXKcXoAVc/AoMNwn9TKx++L/gaen/+4TTttmu8ZSch5vfVJ8uJvGbroTsIlslRg6lg==",
       "dev": true,
+      "license": "Unlicense",
       "dependencies": {
         "fs-monkey": "^1.0.3"
       },
@@ -8728,9 +8791,8 @@
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -8745,9 +8807,8 @@
     },
     "node_modules/methods": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -9321,9 +9382,8 @@
     },
     "node_modules/mime": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -9369,9 +9429,8 @@
     },
     "node_modules/mini-css-extract-plugin": {
       "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.5.tgz",
-      "integrity": "sha512-9HaR++0mlgom81s95vvNjxkg52n2b5s//3ZTI1EtzFb98awsLSivs2LMsVqnQ3ay0PVhqWcGNyDaTE961FOcjQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "schema-utils": "^4.0.0"
       },
@@ -9442,8 +9501,7 @@
     },
     "node_modules/minipass-fetch": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.1.tgz",
-      "integrity": "sha512-t9/wowtf7DYkwz8cfMSt0rMwiyNIBXf5CKZ3S5ZMqRqMYT0oLTp0x1WorMI9WTwvaPg21r1JbFxJMum8JrLGfw==",
+      "license": "MIT",
       "dependencies": {
         "minipass": "^4.0.0",
         "minipass-sized": "^1.0.3",
@@ -9595,9 +9653,8 @@
     },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
-      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "dns-packet": "^5.2.2",
         "thunky": "^1.0.2"
@@ -9759,17 +9816,15 @@
     },
     "node_modules/node-emoji": {
       "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
-      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
       }
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -9922,15 +9977,13 @@
     },
     "node_modules/obuf": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -9940,9 +9993,8 @@
     },
     "node_modules/on-headers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -9970,8 +10022,7 @@
     },
     "node_modules/open": {
       "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "license": "MIT",
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -10153,9 +10204,8 @@
     },
     "node_modules/p-retry": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/retry": "0.12.0",
         "retry": "^0.13.1"
@@ -10166,9 +10216,8 @@
     },
     "node_modules/p-retry/node_modules/retry": {
       "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -10253,9 +10302,8 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -10267,6 +10315,14 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/patch-console": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-1.0.0.tgz",
+      "integrity": "sha512-nxl9nrnLQmh64iTzMfyylSlRozL7kAXIaxw1fVcLYdyhNkJCRUzirRZTikXGJsg+hc4fqpneTK6iU2H1Q8THSA==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/path-browserify": {
@@ -10303,9 +10359,8 @@
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -10331,9 +10386,8 @@
     },
     "node_modules/pend": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -10429,10 +10483,9 @@
     },
     "node_modules/playwright": {
       "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.31.0.tgz",
-      "integrity": "sha512-cFn1ie3bdYw/9/Ty3842CfPSRSy+ZWPjEhrxWgC+jL/CUjq5RKVJZwUbXV1UKBQU1Vo0NetsokXmk9EEZiqVHQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.31.0"
       },
@@ -10445,9 +10498,8 @@
     },
     "node_modules/playwright-core": {
       "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.0.tgz",
-      "integrity": "sha512-/KquBjS5DcASCh8cGeNVHuC0kyb7c9plKTwaKxgOGtxT7+DZO2fjmFvPDBSXslEIK5CeOO/2kk5rOCktFXKEdA==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright": "cli.js"
       },
@@ -10961,9 +11013,8 @@
     },
     "node_modules/prettier": {
       "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -10976,8 +11027,7 @@
     },
     "node_modules/pretty-bytes": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.0.tgz",
-      "integrity": "sha512-Rk753HI8f4uivXi4ZCIYdhmG1V+WKzvRMg/X+M42a6t7D07RcmopXJMDNk6N++7Bl75URRGsb40ruvg7Hcp2wQ==",
+      "license": "MIT",
       "engines": {
         "node": "^14.13.1 || >=16.0.0"
       },
@@ -11017,15 +11067,13 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -11067,8 +11115,7 @@
     },
     "node_modules/properties-parser": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/properties-parser/-/properties-parser-0.3.1.tgz",
-      "integrity": "sha512-AkSQxQAviJ89x4FIxOyHGfO3uund0gvYo7lfD0E+Gp7gFQKrTNgtoYQklu8EhrfHVZUzTwKGZx2r/KDSfnljcA==",
+      "license": "MIT",
       "dependencies": {
         "string.prototype.codepointat": "^0.2.0"
       },
@@ -11086,9 +11133,8 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -11099,9 +11145,8 @@
     },
     "node_modules/proxy-addr/node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
@@ -11142,9 +11187,8 @@
     },
     "node_modules/qs": {
       "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -11210,18 +11254,16 @@
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/raw-body": {
       "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -11234,18 +11276,16 @@
     },
     "node_modules/raw-body/node_modules/bytes": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/raw-body/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -11299,6 +11339,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-devtools-core": {
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.27.4.tgz",
+      "integrity": "sha512-dvZjrAJjahd6NNl7dDwEk5TyHsWJxDpYL7VnD9jdEr98EEEsVhw9G8JDX54Nrb3XIIOBlJDpjo3AuBuychX9zg==",
+      "dependencies": {
+        "shell-quote": "^1.6.1",
+        "ws": "^7"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "license": "MIT",
@@ -11336,8 +11385,7 @@
     },
     "node_modules/react-markdown": {
       "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.5.tgz",
-      "integrity": "sha512-jGJolWWmOWAvzf+xMdB9zwStViODyyFQhNB/bwCerbBKmrTmgmA599CGiOlP58OId1IMoIRsA8UdI1Lod4zb5A==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^2.0.0",
         "@types/prop-types": "^15.0.0",
@@ -11366,13 +11414,11 @@
     },
     "node_modules/react-markdown/node_modules/react-is": {
       "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+      "license": "MIT"
     },
     "node_modules/react-markdown/node_modules/style-to-object": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.1.tgz",
-      "integrity": "sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==",
+      "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.1.1"
       }
@@ -11425,8 +11471,7 @@
     },
     "node_modules/rehype-minify-whitespace": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-5.0.1.tgz",
-      "integrity": "sha512-PPp4lWJiBPlePI/dv1BeYktbwkfgXkrK59MUa+tYbMPgleod+4DvFK2PLU0O0O60/xuhHfiR9GUIUlXTU8sRIQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^2.0.0",
         "hast-util-embedded": "^2.0.0",
@@ -11510,8 +11555,7 @@
     },
     "node_modules/remark-emoji": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-3.1.0.tgz",
-      "integrity": "sha512-KmjkU04niXFMn/H+SsPAGnXhsuq0gT/neIg1KRw8vUKZ/PNxpLDGmwVzx4a14OOd5GJ8rnCdh6DKXqHySkUHAQ==",
+      "license": "MIT",
       "dependencies": {
         "emoticon": "^4.0.1",
         "mdast-util-find-and-replace": "^2.2.2",
@@ -11613,9 +11657,8 @@
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -11677,7 +11720,6 @@
     },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
@@ -11689,7 +11731,6 @@
     },
     "node_modules/restore-cursor/node_modules/mimic-fn": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11697,7 +11738,6 @@
     },
     "node_modules/restore-cursor/node_modules/onetime": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -11753,9 +11793,8 @@
     },
     "node_modules/roarr": {
       "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
-      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
@@ -11832,9 +11871,8 @@
     },
     "node_modules/sass": {
       "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.60.0.tgz",
-      "integrity": "sha512-updbwW6fNb5gGm8qMXzVO7V4sWf7LMXnMly/JEyfbfERbVH46Fn6q02BX7/eHTdKpE7d+oTkMMQpFWNUMfFbgQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -11849,9 +11887,8 @@
     },
     "node_modules/sass-loader": {
       "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.2.2.tgz",
-      "integrity": "sha512-nrIdVAAte3B9icfBiGWvmMhT/D+eCDwnk+yA7VE/76dp/WkHX+i44Q/pfo71NYbwj0Ap+PGsn0ekOuU1WFJ2AA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "klona": "^2.0.6",
         "neo-async": "^2.6.2"
@@ -11947,15 +11984,13 @@
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-      "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/selfsigned": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.1.1.tgz",
-      "integrity": "sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "node-forge": "^1"
       },
@@ -11973,16 +12008,14 @@
     },
     "node_modules/semver-compare": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/send": {
       "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -12004,39 +12037,34 @@
     },
     "node_modules/send/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/send/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/send/node_modules/depd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/serialize-error": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "type-fest": "^0.13.1"
@@ -12050,9 +12078,8 @@
     },
     "node_modules/serialize-error/node_modules/type-fest": {
       "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "optional": true,
       "engines": {
         "node": ">=10"
@@ -12070,9 +12097,8 @@
     },
     "node_modules/serve-index": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-      "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.4",
         "batch": "0.6.1",
@@ -12088,18 +12114,16 @@
     },
     "node_modules/serve-index/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/serve-index/node_modules/http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-      "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -12112,36 +12136,31 @@
     },
     "node_modules/serve-index/node_modules/inherits": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/serve-index/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/serve-index/node_modules/setprototypeof": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/serve-index/node_modules/statuses": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/serve-static": {
       "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -12164,9 +12183,8 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/sha.js": {
       "version": "2.4.11",
@@ -12217,12 +12235,10 @@
     },
     "node_modules/shell-escape": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/shell-escape/-/shell-escape-0.2.0.tgz",
-      "integrity": "sha512-uRRBT2MfEOyxuECseCZd28jC1AJ8hmqqneWQ4VWUTgCAFvb3wKU1jLqj6egC4Exrr88ogg3dp+zroH4wJuaXzw=="
+      "license": "MIT"
     },
     "node_modules/shell-quote": {
       "version": "1.7.4",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -12245,9 +12261,8 @@
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -12263,8 +12278,7 @@
     },
     "node_modules/slash": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -12305,9 +12319,8 @@
     },
     "node_modules/sockjs": {
       "version": "0.3.24",
-      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
-      "integrity": "sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
@@ -12316,9 +12329,8 @@
     },
     "node_modules/sockjs/node_modules/uuid": {
       "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -12412,9 +12424,8 @@
     },
     "node_modules/spdy": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
-      "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.0",
         "handle-thing": "^2.0.0",
@@ -12428,9 +12439,8 @@
     },
     "node_modules/spdy-transport": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
-      "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.0",
         "detect-node": "^2.0.4",
@@ -12457,15 +12467,13 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "optional": true
     },
     "node_modules/ssri": {
       "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.1.tgz",
-      "integrity": "sha512-WVy6di9DlPOeBWEjMScpNipeSX2jIZBGEn5Uuo8Q7aIuFEuDX0pw8RxcOjlD1TWP4obi24ki7m/13+nFpcbXrw==",
+      "license": "ISC",
       "dependencies": {
         "minipass": "^4.0.0"
       },
@@ -12478,6 +12486,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/static-eval": {
       "version": "2.0.2",
       "license": "MIT",
@@ -12487,17 +12514,15 @@
     },
     "node_modules/statuses": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/stdin-discarder": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
-      "integrity": "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==",
+      "license": "MIT",
       "dependencies": {
         "bl": "^5.0.0"
       },
@@ -12510,8 +12535,7 @@
     },
     "node_modules/stdin-discarder/node_modules/bl": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
-      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
+      "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
@@ -12611,8 +12635,7 @@
     },
     "node_modules/string.prototype.codepointat": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
-      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg=="
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.3",
@@ -12689,9 +12712,8 @@
     },
     "node_modules/sumchecker": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
-      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.1.0"
       },
@@ -12712,8 +12734,7 @@
     },
     "node_modules/supports-hyperlinks": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
@@ -12724,16 +12745,14 @@
     },
     "node_modules/supports-hyperlinks/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/supports-hyperlinks/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -12845,8 +12864,7 @@
     },
     "node_modules/terminal-link": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-3.0.0.tgz",
-      "integrity": "sha512-flFL3m4wuixmf6IfhFJd1YPiLiMuxEc8uHRM1buzIeZPm22Au2pDqBJQgdo7n1WfPU1ONFGv7YDwpFBmHGF6lg==",
+      "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^5.0.0",
         "supports-hyperlinks": "^2.2.0"
@@ -12860,8 +12878,7 @@
     },
     "node_modules/terminal-link/node_modules/ansi-escapes": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
-      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^1.0.2"
       },
@@ -12874,8 +12891,7 @@
     },
     "node_modules/terminal-link/node_modules/type-fest": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -12995,9 +13011,8 @@
     },
     "node_modules/thunky": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
-      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/timers-browserify": {
       "version": "2.0.12",
@@ -13047,8 +13062,7 @@
     },
     "node_modules/to-vfile": {
       "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-7.2.4.tgz",
-      "integrity": "sha512-2eQ+rJ2qGbyw3senPI0qjuM7aut8IYXK6AEoOWb+fJx/mQYzviTckm1wDjq91QYHAPBTYzmdJXxMFA6Mk14mdw==",
+      "license": "MIT",
       "dependencies": {
         "is-buffer": "^2.0.0",
         "vfile": "^5.1.0"
@@ -13060,9 +13074,8 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.6"
       }
@@ -13092,8 +13105,7 @@
     },
     "node_modules/trim-trailing-lines": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
-      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -13159,7 +13171,6 @@
     },
     "node_modules/type-fest": {
       "version": "0.21.3",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -13170,9 +13181,8 @@
     },
     "node_modules/type-is": {
       "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -13183,9 +13193,8 @@
     },
     "node_modules/typescript": {
       "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13217,8 +13226,7 @@
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
-      "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+      "license": "ISC",
       "dependencies": {
         "unique-slug": "^4.0.0"
       },
@@ -13228,8 +13236,7 @@
     },
     "node_modules/unique-slug": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
-      "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+      "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4"
       },
@@ -13239,8 +13246,7 @@
     },
     "node_modules/unist-builder": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-3.0.1.tgz",
-      "integrity": "sha512-gnpOw7DIpCA0vpr6NqdPvTWnlPTApCTRzr+38E6hCWx3rz/cjo83SsKIlS1Z+L5ttScQ2AwutNnb8+tAvpb6qQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0"
       },
@@ -13251,8 +13257,7 @@
     },
     "node_modules/unist-util-find-after": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-4.0.1.tgz",
-      "integrity": "sha512-QO/PuPMm2ERxC6vFXEPtmAutOopy5PknD+Oq64gGwxKtk4xwo9Z97t9Av1obPmGU0IyTa6EKYUfTrK2QJS3Ozw==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0"
@@ -13302,8 +13307,7 @@
     },
     "node_modules/unist-util-visit": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
-      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0",
@@ -13316,8 +13320,7 @@
     },
     "node_modules/unist-util-visit-parents": {
       "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
-      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0"
@@ -13336,9 +13339,8 @@
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -13419,8 +13421,7 @@
     },
     "node_modules/use-resize-observer": {
       "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-9.1.0.tgz",
-      "integrity": "sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==",
+      "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.3.1"
       },
@@ -13452,9 +13453,8 @@
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -13484,17 +13484,15 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/vfile": {
       "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
-      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
@@ -13833,9 +13831,8 @@
     },
     "node_modules/wbuf": {
       "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
-      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
       }
@@ -13857,8 +13854,7 @@
     },
     "node_modules/webpack": {
       "version": "5.77.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.77.0.tgz",
-      "integrity": "sha512-sbGNjBr5Ya5ss91yzjeJTLKyfiwo5C628AFjEa6WSXcZa4E+F57om3Cc8xLb1Jh0b243AWuSYRf3dn7HVeFQ9Q==",
+      "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -13974,9 +13970,8 @@
     },
     "node_modules/webpack-dev-middleware": {
       "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "colorette": "^2.0.10",
         "memfs": "^3.4.3",
@@ -13997,9 +13992,8 @@
     },
     "node_modules/webpack-dev-server": {
       "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.13.1.tgz",
-      "integrity": "sha512-5tWg00bnWbYgkN+pd5yISQKDejRBYGEw15RaEEslH+zdbNDxxaZvEAO2WulaSaFKb5n3YG8JXsGaDsut1D0xdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -14056,9 +14050,8 @@
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
       "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -14089,9 +14082,8 @@
     },
     "node_modules/webpack-shell-plugin-next": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/webpack-shell-plugin-next/-/webpack-shell-plugin-next-2.3.1.tgz",
-      "integrity": "sha512-+ozr/BcsuPh2R6j4oxmu9qJCInhhDCQ+Lb/sSUNHuXjoGj+myxxZyjucHze+K9dCoIo22gAoK1yuCP/gSnpUNg==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "webpack": "^5.18.0"
       }
@@ -14121,9 +14113,8 @@
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",
@@ -14135,9 +14126,8 @@
     },
     "node_modules/websocket-extensions": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
-      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -14208,6 +14198,43 @@
         "node": ">=8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/widest-line/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/widest-line/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wildcard": {
       "version": "2.0.0",
       "dev": true,
@@ -14222,8 +14249,7 @@
     },
     "node_modules/wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -14296,8 +14322,7 @@
     },
     "node_modules/write-file-atomic": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.0.tgz",
-      "integrity": "sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==",
+      "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -14380,8 +14405,7 @@
     },
     "node_modules/yargs": {
       "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -14427,9 +14451,8 @@
     },
     "node_modules/yauzl": {
       "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
@@ -14452,6 +14475,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoga-layout-prebuilt": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yoga-layout-prebuilt/-/yoga-layout-prebuilt-1.10.0.tgz",
+      "integrity": "sha512-YnOmtSbv4MTf7RGJMK0FvZ+KD8OEe/J5BNnR0GHhD8J/XcG/Qvxgszm0Un6FTHWW4uHlTgP0IztiXQnGyIR45g==",
+      "dependencies": {
+        "@types/yoga-layout": "1.9.2"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/zip-webpack-plugin": {
@@ -14484,7 +14518,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^7.2.3",
+        "@guidebooks/store": "^7.2.8",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.18",
         "@patternfly/react-core": "^4.276.6",
@@ -14504,6 +14538,42 @@
         "@types/react": "^18.0.28",
         "@types/react-dom": "18.0.11",
         "@types/split2": "^3.2.1"
+      }
+    },
+    "plugins/plugin-codeflare-dashboard": {
+      "name": "@kui-shell/plugin-codeflare-dashboard",
+      "version": "0.0.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@logdna/tail-file": "^3.0.1",
+        "chokidar": "^3.5.3",
+        "ink": "^3.2.0",
+        "madwizard": "^7.0.3",
+        "pretty-ms": "^7.0.1",
+        "strip-ansi": "6.0.0"
+      },
+      "devDependencies": {
+        "@types/split2": "^3.2.1",
+        "react-devtools-core": "^4.27.2"
+      }
+    },
+    "plugins/plugin-codeflare-dashboard/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "plugins/plugin-codeflare-dashboard/node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "plugins/plugin-codeflare/node_modules/ansi-regex": {
@@ -14771,8 +14841,6 @@
     },
     "@electron/get": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.2.tgz",
-      "integrity": "sha512-eFZVFoRXb3GFGd7Ak7W4+6jBl9wBtiZ4AaYOse97ej6mKj5tkyO0dUnUChs1IhJZtx1BENo4/p4WUTXpi6vT+g==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -14787,8 +14855,6 @@
       "dependencies": {
         "fs-extra": {
           "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
@@ -14798,8 +14864,6 @@
         },
         "jsonfile": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
@@ -14807,8 +14871,6 @@
         },
         "universalify": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
         }
       }
@@ -15082,8 +15144,6 @@
     },
     "@ewoudenberg/difflib": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@ewoudenberg/difflib/-/difflib-0.1.0.tgz",
-      "integrity": "sha512-OU5P5mJyD3OoWYMWY+yIgwvgNS9cFAU10f+DDuvtogcWQOoJIsQ4Hy2McSfUfhKjq8L0FuWVb4Rt7kgA+XK86A==",
       "requires": {
         "heap": ">= 0.2.0"
       }
@@ -15096,9 +15156,9 @@
       "dev": true
     },
     "@guidebooks/store": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.2.3.tgz",
-      "integrity": "sha512-v4AJA8JEJ4y00Nt7Y3bisdxFe7+CAFl+w28D6YgCXxmrPAcNMDEvBzn0/DGdoUvfKbdKKyreE3k4fIonXHOFKQ=="
+      "version": "7.2.8",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.2.8.tgz",
+      "integrity": "sha512-GIwJCnhQKYi0L7IJ/Dg1MJ/9ff6FdsFczaK7AVidWZnyfl3ffBjgCSjZs4IMZqdwApFu7lIDccNA4bAoPSPGPg=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -15217,14 +15277,10 @@
       }
     },
     "@juggle/resize-observer": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
-      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
+      "version": "3.4.0"
     },
     "@kui-shell/builder": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/builder/-/builder-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-aFt/FsIrK4+3HINkrQS8L01Z21zCMWehTGj1eHJ/cL0u+MHOjvDbwyRp7oQMAzM1/1kmZsiwgCap3bJBQiqRuw==",
       "dev": true,
       "requires": {
         "@babel/cli": "^7.20.7",
@@ -15248,8 +15304,6 @@
     },
     "@kui-shell/core": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/core/-/core-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-cSGJn+qKLkHSl5jh0YY1dmD1LBTY9MuANyro+JM028CsrVVMtFvEkU4cMzhfkdh1aQz5dC/OAzsAbAwPUekMtw==",
       "requires": {
         "colors": "^1.4.0",
         "columnify": "^1.6.0",
@@ -15283,8 +15337,6 @@
     },
     "@kui-shell/plugin-bash-like": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-bash-like/-/plugin-bash-like-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-JfeoeUHmHaKc4cvfONSw5uOhONDuSiCM2t+fZLkroaCTaSqKASuMtcui8IF1Zdq6PjGzo8c8y8iYYwMLKDnf+w==",
       "requires": {
         "@kui-shell/xterm-helpers": "^2.1.0",
         "cookie": "^0.5.0",
@@ -15305,8 +15357,6 @@
     },
     "@kui-shell/plugin-client-common": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-client-common/-/plugin-client-common-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-VyQvqhCh5EhBUYMcA8EXR/XRl4EhPKoTB46HeE9/trltWAOkpNxXvfgOE+ydVjEC6jqtA50hcy8CPq+KV1DPgQ==",
       "requires": {
         "@fortawesome/fontawesome-free": "^6.2.1",
         "@mdi/font": "^7.1.96",
@@ -15336,16 +15386,14 @@
       },
       "dependencies": {
         "entities": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-          "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
+          "version": "4.4.0"
         }
       }
     },
     "@kui-shell/plugin-codeflare": {
       "version": "file:plugins/plugin-codeflare",
       "requires": {
-        "@guidebooks/store": "^7.2.3",
+        "@guidebooks/store": "^7.2.8",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.18",
         "@patternfly/react-core": "^4.276.6",
@@ -15376,10 +15424,36 @@
         }
       }
     },
+    "@kui-shell/plugin-codeflare-dashboard": {
+      "version": "file:plugins/plugin-codeflare-dashboard",
+      "requires": {
+        "@logdna/tail-file": "^3.0.1",
+        "@types/split2": "^3.2.1",
+        "chokidar": "^3.5.3",
+        "ink": "^3.2.0",
+        "madwizard": "^7.0.3",
+        "pretty-ms": "^7.0.1",
+        "react-devtools-core": "^4.27.2",
+        "strip-ansi": "6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
+    },
     "@kui-shell/plugin-core-support": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-core-support/-/plugin-core-support-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-pVEKpxxdRgkcuu4dV07gB/WNuKlW2vROzevcjaAu2jUYPvgyqK8X7aymQ8zZO0DrLsalfYuXCaOBznP+6wOqlg==",
       "requires": {
         "@supercharge/promise-pool": "^2.3.2",
         "debug": "^4.3.4",
@@ -15388,8 +15462,6 @@
     },
     "@kui-shell/plugin-electron-components": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-electron-components/-/plugin-electron-components-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-klbMV7SVqjs9mPkC43QAc83r/QgIW/JyyxvB7aMiaul1xKp3I59WWoAfJbog8Av72rG45MfeLQXeAjLkIqPPPQ==",
       "requires": {
         "@patternfly/react-core": "^4.264.0",
         "needle": "^3.2.0"
@@ -15397,8 +15469,6 @@
     },
     "@kui-shell/plugin-kubectl": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl/-/plugin-kubectl-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-FWyInAcyHRky2kXzqkx0iTF6tcmrvOpVD4zwSBu7xttdYO+z+YObiujvpLTi2cW2xPd8FMzWdteQLQJ6vSyIEg==",
       "requires": {
         "@kui-shell/jsonpath": "^1.1.1",
         "@kui-shell/plugin-kubectl-core": "^13.1.3-dev-20230329-123301",
@@ -15444,14 +15514,10 @@
       }
     },
     "@kui-shell/plugin-kubectl-core": {
-      "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-kubectl-core/-/plugin-kubectl-core-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-woE3/yldVRGfLwdAoKcAlOem7NbTtbMcgwak0XKJwh1He1E6JFsL6OoJzj6zFVWrIn334Xfsd5XyAad1dzwjlg=="
+      "version": "13.1.3-dev-20230329-123301"
     },
     "@kui-shell/plugin-madwizard": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-madwizard/-/plugin-madwizard-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-IZDSPW+4B3cB54DENBOYYqK4ZNtPtsNC+8wAaEAejLnxfGWTWIlih2PvApa+zusIp+r7OvvijeYJzWWY2O1guQ==",
       "requires": {
         "@patternfly/react-core": "^4.267.6",
         "allotment": "^1.18.1",
@@ -15472,25 +15538,17 @@
       }
     },
     "@kui-shell/plugin-patternfly4-themes": {
-      "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-patternfly4-themes/-/plugin-patternfly4-themes-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-SguVXC/rHGYwO0MJbM1LZJqbSaFFtQzVuLDW12wjd2QUPqW4gDHnfsyAy3PVJEsGQLMagIMFyyLE4xa7/vnvfQ=="
+      "version": "13.1.3-dev-20230329-123301"
     },
     "@kui-shell/plugin-proxy-support": {
-      "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/plugin-proxy-support/-/plugin-proxy-support-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-18ky5/TjIRmymhGIYxuCoxyab20/zblIhLVD5eJxqF1sMheMJ+EVoMTiH7zi4IaCVeBTyoNW7T2D822pA6rvvw=="
+      "version": "13.1.3-dev-20230329-123301"
     },
     "@kui-shell/proxy": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/proxy/-/proxy-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-IcgOw9ztpbZyvcj89hJBYwALPz9tPM2BWQNDYhKYvy87yH8aRPWFOfxlZgO9k6GgbIulmZrwxWAlR0ak7cg7WQ==",
       "dev": true
     },
     "@kui-shell/react": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/react/-/react-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-a6NVtUBIeZhKTvnhYUI7KBl3kh6HCoygtmZByVivIMJD2c3FzCIGOoahGM32TycBckiPk7N2bXySF4+xHsVhLA==",
       "dev": true,
       "requires": {
         "react": "^18.2.0",
@@ -15499,8 +15557,6 @@
     },
     "@kui-shell/webpack": {
       "version": "13.1.3-dev-20230329-123301",
-      "resolved": "https://registry.npmjs.org/@kui-shell/webpack/-/webpack-13.1.3-dev-20230329-123301.tgz",
-      "integrity": "sha512-bFR0rVRGoRTIHyQJ1Xg7bkSh2LjnGwxY6vidvd6Rc+ogXa+IzXAEoVhThs+JQ12Fs1CMyRlzpv/EtDW4X6rCvA==",
       "dev": true,
       "requires": {
         "assert": "^2.0.0",
@@ -15550,14 +15606,10 @@
     },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
-      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
     },
     "@logdna/tail-file": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@logdna/tail-file/-/tail-file-3.0.1.tgz",
-      "integrity": "sha512-c7Ve4yYM/aHzYb9njTP/mdZtw4MAD+On/1I1XhvfrWUHud2XZ1KyhKnWRNXfbJHuHMtcL2GIjQ8V4a/yb4hygw=="
+      "version": "3.0.1"
     },
     "@malept/cross-spawn-promise": {
       "version": "2.0.0",
@@ -15593,32 +15645,24 @@
     },
     "@npmcli/fs": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.0.tgz",
-      "integrity": "sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==",
       "requires": {
         "semver": "^7.3.5"
       },
       "dependencies": {
         "lru-cache": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "semver": {
           "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+          "version": "4.0.0"
         }
       }
     },
@@ -15632,8 +15676,6 @@
     },
     "@patternfly/react-charts": {
       "version": "6.94.18",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.94.18.tgz",
-      "integrity": "sha512-56WxnZYC3blRX41mW67JaPxJ3YhXViLvwGpEsZrYCccla/rTV8JgKK0gjHnqtzPQiVBfpn+3ewOyNCOR5uRoSw==",
       "requires": {
         "@patternfly/react-styles": "^4.92.6",
         "@patternfly/react-tokens": "^4.94.6",
@@ -15660,8 +15702,6 @@
     },
     "@patternfly/react-core": {
       "version": "4.276.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.276.6.tgz",
-      "integrity": "sha512-G0K+378jf9jw9g+hCAoKnsAe/UGTRspqPeuAYypF2FgNr+dC7dUpc7/VkNhZBVqSJzUWVEK8NyXcqkfi0IemIg==",
       "requires": {
         "@patternfly/react-icons": "^4.93.6",
         "@patternfly/react-styles": "^4.92.6",
@@ -15674,19 +15714,13 @@
     },
     "@patternfly/react-icons": {
       "version": "4.93.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.93.6.tgz",
-      "integrity": "sha512-ZrXegc/81oiuTIeWvoHb3nG/eZODbB4rYmekBEsrbiysyO7m/sUFoi/RLvgFINrRoh6YCJqL5fj06Jg6d7jX1g==",
       "requires": {}
     },
     "@patternfly/react-styles": {
-      "version": "4.92.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.92.6.tgz",
-      "integrity": "sha512-b8uQdEReMyeoMzjpMri845QxqtupY/tIFFYfVeKoB2neno8gkcW1RvDdDe62LF88q45OktCwAe/8A99ker10Iw=="
+      "version": "4.92.6"
     },
     "@patternfly/react-table": {
       "version": "4.112.39",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.112.39.tgz",
-      "integrity": "sha512-U+hOMgYlbghGH4M5MX+qt0GkVi/ocrGnxDnm11YiS3CtEGsd6Rr0NeqMmk0uoR46Od4Pr5tKuXxZhPP32sCL/w==",
       "requires": {
         "@patternfly/react-core": "^4.276.6",
         "@patternfly/react-icons": "^4.93.6",
@@ -15697,14 +15731,10 @@
       }
     },
     "@patternfly/react-tokens": {
-      "version": "4.94.6",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.94.6.tgz",
-      "integrity": "sha512-tm7C6nat+uKMr1hrapis7hS3rN9cr41tpcCKhx6cod6FLU8KwF2Yt5KUxakhIOCEcE/M/EhXhAw/qejp8w0r7Q=="
+      "version": "4.94.6"
     },
     "@playwright/test": {
       "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.0.tgz",
-      "integrity": "sha512-Ys5s/06Dg9g3zAIdCIb/UOBYim3U7Zjb3DvC6XBtnRmnglH5O47iwYzmtxXu9fhSyzI2Jn28apkXIOD81GgCdw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -15739,8 +15769,6 @@
     },
     "@types/body-parser": {
       "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
-      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
       "dev": true,
       "requires": {
         "@types/connect": "*",
@@ -15749,8 +15777,6 @@
     },
     "@types/bonjour": {
       "version": "3.5.10",
-      "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.10.tgz",
-      "integrity": "sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -15768,8 +15794,6 @@
     },
     "@types/connect": {
       "version": "3.4.35",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
-      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -15777,8 +15801,6 @@
     },
     "@types/connect-history-api-fallback": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz",
-      "integrity": "sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==",
       "dev": true,
       "requires": {
         "@types/express-serve-static-core": "*",
@@ -15846,8 +15868,6 @@
     },
     "@types/express": {
       "version": "4.17.17",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
-      "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
@@ -15858,8 +15878,6 @@
     },
     "@types/express-serve-static-core": {
       "version": "4.17.33",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
-      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -15868,9 +15886,7 @@
       }
     },
     "@types/extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw=="
+      "version": "3.0.1"
     },
     "@types/hast": {
       "version": "2.3.4",
@@ -15888,8 +15904,6 @@
     },
     "@types/http-proxy": {
       "version": "1.17.10",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.10.tgz",
-      "integrity": "sha512-Qs5aULi+zV1bwKAg5z1PWnDXWmsn+LxIvUGv6E2+OOMYhclZMO+OXd9pYVf2gLykf2I7IV2u7oTHwChPNsvJ7g==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -15931,8 +15945,6 @@
     },
     "@types/mime": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
-      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
       "dev": true
     },
     "@types/ms": {
@@ -15940,8 +15952,6 @@
     },
     "@types/needle": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/needle/-/needle-3.2.0.tgz",
-      "integrity": "sha512-6XzvzEyJ2ozFNfPajFmqH9JOt0Hp+9TawaYpJT59iIP/zR0U37cfWCRwosyIeEBBZBi021Osq4jGAD3AOju5fg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -15958,20 +15968,14 @@
     },
     "@types/qs": {
       "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "dev": true
     },
     "@types/range-parser": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
     },
     "@types/react": {
       "version": "18.0.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
-      "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -15980,8 +15984,6 @@
     },
     "@types/react-dom": {
       "version": "18.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
-      "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -15996,8 +15998,6 @@
     },
     "@types/retry": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
     },
     "@types/scheduler": {
@@ -16005,14 +16005,10 @@
     },
     "@types/semver": {
       "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
     },
     "@types/serve-index": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.1.tgz",
-      "integrity": "sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==",
       "dev": true,
       "requires": {
         "@types/express": "*"
@@ -16020,8 +16016,6 @@
     },
     "@types/serve-static": {
       "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.1.tgz",
-      "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
       "dev": true,
       "requires": {
         "@types/mime": "*",
@@ -16030,8 +16024,6 @@
     },
     "@types/sockjs": {
       "version": "0.3.33",
-      "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.33.tgz",
-      "integrity": "sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -16049,8 +16041,6 @@
     },
     "@types/ws": {
       "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
-      "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -16069,18 +16059,19 @@
     },
     "@types/yauzl": {
       "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
       "dev": true,
       "optional": true,
       "requires": {
         "@types/node": "*"
       }
     },
+    "@types/yoga-layout": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz",
+      "integrity": "sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw=="
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.53.0.tgz",
-      "integrity": "sha512-alFpFWNucPLdUOySmXCJpzr6HKC3bu7XooShWM+3w/EL6J2HIoB2PFxpLnq4JauWVk6DiVeNKzQlFEaE+X9sGw==",
       "dev": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.53.0",
@@ -16117,8 +16108,6 @@
     },
     "@typescript-eslint/parser": {
       "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.53.0.tgz",
-      "integrity": "sha512-MKBw9i0DLYlmdOb3Oq/526+al20AJZpANdT6Ct9ffxcV8nKCHz63t/S0IhlTFNsBIHJv+GY5SFJ0XfqVeydQrQ==",
       "dev": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.53.0",
@@ -16129,8 +16118,6 @@
     },
     "@typescript-eslint/scope-manager": {
       "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.53.0.tgz",
-      "integrity": "sha512-Opy3dqNsp/9kBBeCPhkCNR7fmdSQqA+47r21hr9a14Bx0xnkElEQmhoHga+VoaoQ6uDHjDKmQPIYcUcKJifS7w==",
       "dev": true,
       "requires": {
         "@typescript-eslint/types": "5.53.0",
@@ -16139,8 +16126,6 @@
     },
     "@typescript-eslint/type-utils": {
       "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.53.0.tgz",
-      "integrity": "sha512-HO2hh0fmtqNLzTAme/KnND5uFNwbsdYhCZghK2SoxGp3Ifn2emv+hi0PBUjzzSh0dstUIFqOj3bp0AwQlK4OWw==",
       "dev": true,
       "requires": {
         "@typescript-eslint/typescript-estree": "5.53.0",
@@ -16151,14 +16136,10 @@
     },
     "@typescript-eslint/types": {
       "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.53.0.tgz",
-      "integrity": "sha512-5kcDL9ZUIP756K6+QOAfPkigJmCPHcLN7Zjdz76lQWWDdzfOhZDTj1irs6gPBKiXx5/6O3L0+AvupAut3z7D2A==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
       "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.53.0.tgz",
-      "integrity": "sha512-eKmipH7QyScpHSkhbptBBYh9v8FxtngLquq292YTEQ1pxVs39yFBlLC1xeIZcPPz1RWGqb7YgERJRGkjw8ZV7w==",
       "dev": true,
       "requires": {
         "@typescript-eslint/types": "5.53.0",
@@ -16172,8 +16153,6 @@
       "dependencies": {
         "lru-cache": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"
@@ -16181,8 +16160,6 @@
         },
         "semver": {
           "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -16190,16 +16167,12 @@
         },
         "yallist": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
         }
       }
     },
     "@typescript-eslint/utils": {
       "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.53.0.tgz",
-      "integrity": "sha512-VUOOtPv27UNWLxFwQK/8+7kvxVC+hPHNsJjzlJyotlaHjLSIgOCKj9I0DBUjwOOA64qjBwx5afAPjksqOxMO0g==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
@@ -16214,8 +16187,6 @@
       "dependencies": {
         "lru-cache": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "dev": true,
           "requires": {
             "yallist": "^4.0.0"
@@ -16223,8 +16194,6 @@
         },
         "semver": {
           "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -16232,16 +16201,12 @@
         },
         "yallist": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
         }
       }
     },
     "@typescript-eslint/visitor-keys": {
       "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.53.0.tgz",
-      "integrity": "sha512-JqNLnX3leaHFZEN0gCh81sIvgrp/2GOACZNgO4+Tkf64u51kTpAyWFOY8XHx8XuXr3N2C9zgPPHtcpMg6z1g0w==",
       "dev": true,
       "requires": {
         "@typescript-eslint/types": "5.53.0",
@@ -16380,8 +16345,6 @@
     },
     "accepts": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "dev": true,
       "requires": {
         "mime-types": "~2.1.34",
@@ -16459,8 +16422,6 @@
     },
     "allotment": {
       "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/allotment/-/allotment-1.18.1.tgz",
-      "integrity": "sha512-ZhmpHoSvxHyPT5XjzTHeCBjzCMIFn1aGdNAzBCZhj1CcRMp31CaJCi+lfweoOLDbbjJqbFZqUk3xf+p7Mb0x5A==",
       "requires": {
         "classnames": "^2.3.0",
         "eventemitter3": "^5.0.0",
@@ -16471,9 +16432,7 @@
       },
       "dependencies": {
         "eventemitter3": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.0.tgz",
-          "integrity": "sha512-riuVbElZZNXLeLEoprfNYoDSwTBRR44X3mnhdI1YcnENpWTCsTTVZ2zFuqQcpoyqPQIUXdiPEU0ECAq0KQRaHg=="
+          "version": "5.0.0"
         }
       }
     },
@@ -16485,15 +16444,12 @@
     },
     "ansi-escapes": {
       "version": "4.3.2",
-      "dev": true,
       "requires": {
         "type-fest": "^0.21.3"
       }
     },
     "ansi-html-community": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
-      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
       "dev": true
     },
     "ansi-regex": {
@@ -16530,8 +16486,6 @@
     },
     "array-flatten": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
-      "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
       "dev": true
     },
     "array-union": {
@@ -16539,8 +16493,6 @@
     },
     "asciinema-player": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/asciinema-player/-/asciinema-player-3.1.0.tgz",
-      "integrity": "sha512-O36+vQOreHW2w9Sao7AbHY4o3RJW7AxtVGtQdb74QkKZmaY8VzQJ3u36PTzltqlybJIpwXY9yK/PdVVmgmTEpg==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "solid-js": "^1.3.0"
@@ -16573,14 +16525,18 @@
       }
     },
     "astral-regex": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "attr-accept": {
       "version": "1.1.3",
       "requires": {
         "core-js": "^2.5.0"
       }
+    },
+    "auto-bind": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
+      "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ=="
     },
     "available-typed-arrays": {
       "version": "1.0.5",
@@ -16608,8 +16564,6 @@
     },
     "batch": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "dev": true
     },
     "big.js": {
@@ -16643,8 +16597,6 @@
     },
     "body-parser": {
       "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
       "dev": true,
       "requires": {
         "bytes": "3.1.2",
@@ -16663,14 +16615,10 @@
       "dependencies": {
         "bytes": {
           "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-          "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
           "dev": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -16678,14 +16626,10 @@
         },
         "depd": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
           "dev": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -16693,16 +16637,12 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
       }
     },
     "bonjour-service": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.1.tgz",
-      "integrity": "sha512-Z/5lQRMOG9k7W+FkeGTNjh7htqn/2LMnfOvBZ8pynNZCM9MwkQkI3zeI4oz09uWdcgmgHugVvBqxGg4VQJ5PCg==",
       "dev": true,
       "requires": {
         "array-flatten": "^2.1.2",
@@ -16717,8 +16657,6 @@
     },
     "boolean": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "dev": true,
       "optional": true
     },
@@ -16833,8 +16771,6 @@
     },
     "bytes": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
       "dev": true
     },
     "bytes-iec": {
@@ -16842,8 +16778,6 @@
     },
     "cacache": {
       "version": "17.0.4",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.0.4.tgz",
-      "integrity": "sha512-Z/nL3gU+zTUjz5pCA5vVjYM8pmaw2kxM7JEiE0fv3w77Wj+sFbi70CrBruUWH0uNcEdvLDixFpgA2JM4F4DBjA==",
       "requires": {
         "@npmcli/fs": "^3.1.0",
         "fs-minipass": "^3.0.0",
@@ -16862,16 +16796,12 @@
       "dependencies": {
         "brace-expansion": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "requires": {
             "balanced-match": "^1.0.0"
           }
         },
         "glob": {
           "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -16881,14 +16811,10 @@
           }
         },
         "lru-cache": {
-          "version": "7.14.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-          "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA=="
+          "version": "7.14.1"
         },
         "minimatch": {
           "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -17001,9 +16927,7 @@
       }
     },
     "classnames": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+      "version": "2.3.2"
     },
     "clean-css": {
       "version": "5.3.1",
@@ -17015,9 +16939,13 @@
     "clean-stack": {
       "version": "2.2.0"
     },
+    "cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw=="
+    },
     "cli-cursor": {
       "version": "3.1.0",
-      "dev": true,
       "requires": {
         "restore-cursor": "^3.1.0"
       }
@@ -17076,6 +17004,14 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "code-excerpt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-3.0.0.tgz",
+      "integrity": "sha512-VHNTVhd7KsLGOqfX3SyeO8RyYPMp1GJOg194VITk04WMYCv4plV68YWe6TJZxd9MhobjtpMRnVky01gqZsalaw==",
+      "requires": {
+        "convert-to-spaces": "^1.0.1"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "dev": true,
@@ -17121,8 +17057,6 @@
     },
     "compressible": {
       "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
-      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
       "dev": true,
       "requires": {
         "mime-db": ">= 1.43.0 < 2"
@@ -17130,8 +17064,6 @@
     },
     "compression": {
       "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
-      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.5",
@@ -17145,8 +17077,6 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -17154,14 +17084,10 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         }
       }
@@ -17242,8 +17168,6 @@
     },
     "connect-history-api-fallback": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
-      "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
       "dev": true
     },
     "console-control-strings": {
@@ -17256,8 +17180,6 @@
     },
     "content-disposition": {
       "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "dev": true,
       "requires": {
         "safe-buffer": "5.2.1"
@@ -17265,21 +17187,22 @@
     },
     "content-type": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true
     },
     "convert-source-map": {
       "version": "1.9.0",
       "dev": true
     },
+    "convert-to-spaces": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-1.0.2.tgz",
+      "integrity": "sha512-cj09EBuObp9gZNQCzc7hByQyrs6jVGE+o9kSJmeUoj+GiPiJvi5LYqEH/Hmme4+MTLHM+Ejtq+FChpjjEnsPdQ=="
+    },
     "cookie": {
       "version": "0.5.0"
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
     },
     "copy-webpack-plugin": {
@@ -17323,8 +17246,6 @@
     },
     "core-util-is": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
     "create-ecdh": {
@@ -17632,8 +17553,6 @@
     },
     "default-gateway": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
-      "integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
       "dev": true,
       "requires": {
         "execa": "^5.0.0"
@@ -17641,8 +17560,6 @@
       "dependencies": {
         "execa": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-          "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.3",
@@ -17658,32 +17575,22 @@
         },
         "get-stream": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
           "dev": true
         },
         "human-signals": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-          "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
           "dev": true
         },
         "is-stream": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
           "dev": true
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
         },
         "npm-run-path": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
           "dev": true,
           "requires": {
             "path-key": "^3.0.0"
@@ -17691,8 +17598,6 @@
         },
         "onetime": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
           "dev": true,
           "requires": {
             "mimic-fn": "^2.1.0"
@@ -17700,8 +17605,6 @@
         },
         "strip-final-newline": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-          "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
           "dev": true
         }
       }
@@ -17756,8 +17659,6 @@
     },
     "destroy": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "dev": true
     },
     "detect-libc": {
@@ -17794,14 +17695,10 @@
     },
     "dns-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-      "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==",
       "dev": true
     },
     "dns-packet": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.5.0.tgz",
-      "integrity": "sha512-USawdAUzRkV6xrqTjiAEp6M9YagZEzWcSUaZTcIFAiyQWW1SoI6KyId8y2+/71wbgHKQAKd+iupLv4YvEwYWvA==",
       "dev": true,
       "requires": {
         "@leichtgewicht/ip-codec": "^2.0.1"
@@ -17863,8 +17760,6 @@
     },
     "dreamopt": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.8.0.tgz",
-      "integrity": "sha512-vyJTp8+mC+G+5dfgsY+r3ckxlz+QMX40VjPQsZc5gxVAxLmi64TBoVkP54A/pRAXMXsbu2GMMBrZPxNv23waMg==",
       "requires": {
         "wordwrap": ">=0.0.2"
       }
@@ -17875,14 +17770,10 @@
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true
     },
     "electron": {
       "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-22.3.0.tgz",
-      "integrity": "sha512-RYraLSk4KitmdIuA1jZzOrzGC9g3u6vxDR5VR6K6jFLw295LOkWiuUorbuFrJ/yftRQBr8+F7S1bqak/Po5xlw==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",
@@ -17892,8 +17783,6 @@
       "dependencies": {
         "@types/node": {
           "version": "16.18.11",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
-          "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==",
           "dev": true
         }
       }
@@ -17928,14 +17817,10 @@
       "version": "3.0.0"
     },
     "emoticon": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/emoticon/-/emoticon-4.0.1.tgz",
-      "integrity": "sha512-dqx7eA9YaqyvYtUhJwT4rC1HIp82j5ybS1/vQ42ur+jBe17dJMwZE4+gvL1XadSFfxaPFFGt3Xsw+Y8akThDlw=="
+      "version": "4.0.1"
     },
     "encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true
     },
     "encoding": {
@@ -17961,7 +17846,7 @@
     },
     "enquirer": {
       "version": "git+https://git@github.com/starpit/enquirer.git#d4dec9ed10d498efeb401eb99517d64f345056d9",
-      "integrity": "sha512-NkTuQL03Tz3xnBFqrPfTuu5q5ee80hS/77ercSgh4NhFnguFqtJIzUOBJBBFyv15nd6stELeeJ5i+esED5g6fQ==",
+      "integrity": "sha512-IzfZT91hHuQLPdfgGvwaQrAD9GDTgO/8qxNs1mrAaAZcYsAlgl8UMLXSZtqfw+0ATErcBH0RAqEVYqOgDG1Zzw==",
       "from": "enquirer@>= 2.3.0 < 3",
       "requires": {
         "ansi-colors": "^4.1.1",
@@ -17988,8 +17873,6 @@
     },
     "es6-error": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true,
       "optional": true
     },
@@ -18002,8 +17885,6 @@
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true
     },
     "escape-string-regexp": {
@@ -18054,8 +17935,6 @@
     },
     "eslint": {
       "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.34.0.tgz",
-      "integrity": "sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.4.1",
@@ -18240,14 +18119,10 @@
     },
     "etag": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true
     },
     "eventemitter3": {
       "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
     },
     "events": {
@@ -18283,14 +18158,10 @@
       }
     },
     "expand-home-dir": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/expand-home-dir/-/expand-home-dir-0.0.3.tgz",
-      "integrity": "sha512-f4P4+coDbYiQPui6LHV4DQFEvzINm9de9w7f+4kz5aGM5kcoe8zc7hnrOLAO7+NAlCLJtNhepUqkLDMKRPQoLA=="
+      "version": "0.0.3"
     },
     "express": {
       "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.8",
@@ -18328,14 +18199,10 @@
       "dependencies": {
         "array-flatten": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-          "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
           "dev": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -18343,14 +18210,10 @@
         },
         "depd": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
       }
@@ -18360,8 +18223,6 @@
     },
     "extract-zip": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "requires": {
         "@types/yauzl": "^2.9.1",
@@ -18407,8 +18268,6 @@
     },
     "faye-websocket": {
       "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
-      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
       "dev": true,
       "requires": {
         "websocket-driver": ">=0.5.1"
@@ -18416,8 +18275,6 @@
     },
     "fd-slicer": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
@@ -18425,17 +18282,13 @@
     },
     "figures": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
-      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
       "requires": {
         "escape-string-regexp": "^5.0.0",
         "is-unicode-supported": "^1.2.0"
       },
       "dependencies": {
         "escape-string-regexp": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+          "version": "5.0.0"
         }
       }
     },
@@ -18479,8 +18332,6 @@
     },
     "finalhandler": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -18494,8 +18345,6 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -18503,8 +18352,6 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
       }
@@ -18537,8 +18384,6 @@
     },
     "follow-redirects": {
       "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "dev": true
     },
     "for-each": {
@@ -18553,50 +18398,36 @@
     },
     "forwarded": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true
     },
     "fresh": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true
     },
     "front-matter": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-4.0.2.tgz",
-      "integrity": "sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==",
       "requires": {
         "js-yaml": "^3.13.1"
       },
       "dependencies": {
         "argparse": {
           "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
           "requires": {
             "sprintf-js": "~1.0.2"
           }
         },
         "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+          "version": "4.0.1"
         },
         "js-yaml": {
           "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
           }
         },
         "sprintf-js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+          "version": "1.0.3"
         }
       }
     },
@@ -18611,16 +18442,12 @@
     },
     "fs-minipass": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.1.tgz",
-      "integrity": "sha512-MhaJDcFRTuLidHrIttu0RDGyyXs/IYHVmlcxfLAEFIWjc1vdLAkdwT7Ace2u7DbitWC0toKMl5eJZRYNVreIMw==",
       "requires": {
         "minipass": "^4.0.0"
       }
     },
     "fs-monkey": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
-      "integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==",
       "dev": true
     },
     "fs-readdir-recursive": {
@@ -18718,8 +18545,6 @@
     },
     "global-agent": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
-      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -18733,8 +18558,6 @@
       "dependencies": {
         "lru-cache": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -18743,8 +18566,6 @@
         },
         "semver": {
           "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -18753,8 +18574,6 @@
         },
         "yallist": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true,
           "optional": true
         }
@@ -18766,8 +18585,6 @@
     },
     "globalthis": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
-      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -18776,8 +18593,6 @@
     },
     "globby": {
       "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -18820,8 +18635,6 @@
     },
     "handle-thing": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
-      "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
     },
     "has": {
@@ -18893,8 +18706,6 @@
     },
     "hast-util-embedded": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-2.0.1.tgz",
-      "integrity": "sha512-QUdSOP1/o+/TxXtpPFXR2mUg2P+ySrmlX7QjwHZCXqMFyYk7YmcGSvqRW+4XgXAoHifdE1t2PwFaQK33TqVjSw==",
       "requires": {
         "hast-util-is-element": "^2.0.0"
       }
@@ -18923,8 +18734,6 @@
     },
     "hast-util-is-body-ok-link": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-2.0.0.tgz",
-      "integrity": "sha512-S58hCexyKdD31vMsErvgLfflW6vYWo/ixRLPJTtkOvLld24vyI8vmYmkgLA5LG3la2ME7nm7dLGdm48gfLRBfw==",
       "requires": {
         "@types/hast": "^2.0.0",
         "hast-util-has-property": "^2.0.0",
@@ -18933,8 +18742,6 @@
     },
     "hast-util-is-element": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.3.tgz",
-      "integrity": "sha512-O1bKah6mhgEq2WtVMk+Ta5K7pPMqsBBlmzysLdcwKVrqzZQ0CHqUPiIVspNhAG1rvxpvJjtGee17XfauZYKqVA==",
       "requires": {
         "@types/hast": "^2.0.0",
         "@types/unist": "^2.0.0"
@@ -18948,8 +18755,6 @@
     },
     "hast-util-phrasing": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-2.0.2.tgz",
-      "integrity": "sha512-yGkCfPkkfCyiLfK6KEl/orMDr/zgCnq/NaO9HfULx6/Zga5fso5eqQA5Ov/JZVqACygvw9shRYWgXNcG2ilo7w==",
       "requires": {
         "@types/hast": "^2.0.0",
         "hast-util-embedded": "^2.0.0",
@@ -18976,8 +18781,6 @@
     },
     "hast-util-to-html": {
       "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-8.0.4.tgz",
-      "integrity": "sha512-4tpQTUOr9BMjtYyNlt0P50mH7xj0Ks2xpo8M943Vykljf99HW6EzulIoJP1N3eKOSScEHzyzi9dm7/cn0RfGwA==",
       "requires": {
         "@types/hast": "^2.0.0",
         "@types/unist": "^2.0.0",
@@ -18994,8 +18797,6 @@
     },
     "hast-util-to-mdast": {
       "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-9.0.0.tgz",
-      "integrity": "sha512-7Pl4mWA3JCSHx0s3A1CgJaFirkISDUJsu+DeJd/cHUAlVDgs1sITzg9HZAidSf9LUE7kl8Hf2ZJr1HZTfhV/Yw==",
       "requires": {
         "@types/extend": "^3.0.0",
         "@types/hast": "^2.0.0",
@@ -19033,8 +18834,6 @@
     },
     "hast-util-to-text": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-3.1.2.tgz",
-      "integrity": "sha512-tcllLfp23dJJ+ju5wCCZHVpzsQQ43+moJbqVX3jNWPB7z/KFC4FyZD6R7y94cHL6MQ33YtMZL8Z0aIXXI4XFTw==",
       "requires": {
         "@types/hast": "^2.0.0",
         "@types/unist": "^2.0.0",
@@ -19060,9 +18859,7 @@
       "dev": true
     },
     "heap": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
-      "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg=="
+      "version": "0.2.7"
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -19081,8 +18878,6 @@
     },
     "hpack.js": {
       "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-      "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -19093,8 +18888,6 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -19108,14 +18901,10 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -19125,8 +18914,6 @@
     },
     "html-entities": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
-      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==",
       "dev": true
     },
     "html-minifier-terser": {
@@ -19173,20 +18960,14 @@
       }
     },
     "http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+      "version": "4.1.1"
     },
     "http-deceiver": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-      "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
       "dev": true
     },
     "http-errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "dev": true,
       "requires": {
         "depd": "2.0.0",
@@ -19198,22 +18979,16 @@
       "dependencies": {
         "depd": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
           "dev": true
         }
       }
     },
     "http-parser-js": {
       "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
-      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==",
       "dev": true
     },
     "http-proxy": {
       "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "dev": true,
       "requires": {
         "eventemitter3": "^4.0.0",
@@ -19231,8 +19006,6 @@
     },
     "http-proxy-middleware": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
       "dev": true,
       "requires": {
         "@types/http-proxy": "^1.17.8",
@@ -19244,8 +19017,6 @@
       "dependencies": {
         "is-plain-obj": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-          "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
           "dev": true
         }
       }
@@ -19306,8 +19077,6 @@
     },
     "immutable": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
-      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
       "dev": true
     },
     "import-fresh": {
@@ -19346,13 +19115,159 @@
     "inherits": {
       "version": "2.0.4"
     },
+    "ink": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-3.2.0.tgz",
+      "integrity": "sha512-firNp1q3xxTzoItj/eOOSZQnYSlyrWks5llCTVX37nJ59K3eXbQ8PtzCguqo8YI19EELo5QxaKnJd4VxzhU8tg==",
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "auto-bind": "4.0.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.0",
+        "cli-cursor": "^3.1.0",
+        "cli-truncate": "^2.1.0",
+        "code-excerpt": "^3.0.0",
+        "indent-string": "^4.0.0",
+        "is-ci": "^2.0.0",
+        "lodash": "^4.17.20",
+        "patch-console": "^1.0.0",
+        "react-devtools-core": "^4.19.1",
+        "react-reconciler": "^0.26.2",
+        "scheduler": "^0.20.2",
+        "signal-exit": "^3.0.2",
+        "slice-ansi": "^3.0.0",
+        "stack-utils": "^2.0.2",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.12.0",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^6.2.0",
+        "ws": "^7.5.5",
+        "yoga-layout-prebuilt": "^1.9.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cli-truncate": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+          "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+          "requires": {
+            "slice-ansi": "^3.0.0",
+            "string-width": "^4.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "react-reconciler": {
+          "version": "0.26.2",
+          "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.26.2.tgz",
+          "integrity": "sha512-nK6kgY28HwrMNwDnMui3dvm3rCFjZrcGiuwLc5COUipBK5hWHLOxMJhSnSomirqWwjPBJKV1QcbkI0VJr7Gl1Q==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "scheduler": "^0.20.2"
+          }
+        },
+        "scheduler": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+          "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "slice-ansi": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+          "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
+          "integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg=="
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
     "inline-style-parser": {
       "version": "0.1.1"
     },
     "install": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/install/-/install-0.13.0.tgz",
-      "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA=="
+      "version": "0.13.0"
     },
     "internmap": {
       "version": "2.0.3"
@@ -19365,8 +19280,6 @@
     },
     "ipaddr.js": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
-      "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
       "dev": true
     },
     "is-alphabetical": {
@@ -19399,6 +19312,21 @@
     "is-callable": {
       "version": "1.2.7",
       "dev": true
+    },
+    "is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "requires": {
+        "ci-info": "^2.0.0"
+      },
+      "dependencies": {
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+        }
+      }
     },
     "is-core-module": {
       "version": "2.11.0",
@@ -19483,9 +19411,7 @@
       }
     },
     "is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="
+      "version": "1.3.0"
     },
     "is-wsl": {
       "version": "2.2.0",
@@ -19495,8 +19421,6 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true
     },
     "isexe": {
@@ -19606,8 +19530,6 @@
     },
     "json-diff": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-1.0.3.tgz",
-      "integrity": "sha512-W0yk/xzjz7bag9v9eS4qthvPG4O07uxNeXwirhvcOqmX4w8HLtB/Pw76o5Z7Pblwvf4vpCi4+iHOlHDnmav/rA==",
       "requires": {
         "@ewoudenberg/difflib": "0.1.0",
         "colors": "^1.4.0",
@@ -19660,14 +19582,10 @@
     },
     "klona": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
-      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
       "dev": true
     },
     "launch-editor": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.0.tgz",
-      "integrity": "sha512-JpDCcQnyAAzZZaZ7vEiSqL690w7dAEyLao+KC96zBplnYbJS7TYNjvM3M7y3dGz+v7aIsJk3hllWuc0kWAjyRQ==",
       "dev": true,
       "requires": {
         "picocolors": "^1.0.0",
@@ -19688,8 +19606,6 @@
     },
     "lint-staged": {
       "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.1.2.tgz",
-      "integrity": "sha512-K9b4FPbWkpnupvK3WXZLbgu9pchUJ6N7TtVZjbaPsoizkqFUDkUReUL25xdrCljJs7uLUF3tZ7nVPeo/6lp+6w==",
       "dev": true,
       "requires": {
         "cli-truncate": "^3.1.0",
@@ -19807,19 +19723,13 @@
       "version": "4.17.21"
     },
     "lodash.clamp": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.clamp/-/lodash.clamp-4.0.3.tgz",
-      "integrity": "sha512-HvzRFWjtcguTW7yd8NJBshuNaCa8aqNFtnswdT7f/cMd/1YKy5Zzoq4W/Oxvnx9l7aeY258uSdDfM793+eLsVg=="
+      "version": "4.0.3"
     },
     "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+      "version": "4.0.8"
     },
     "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+      "version": "4.5.0"
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -19987,13 +19897,11 @@
     },
     "madwizard": {
       "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/madwizard/-/madwizard-7.0.4.tgz",
-      "integrity": "sha512-9ri2Wf0sr5FfK7wvugSSXwUO8ueO2aIaglRAUsFn+wMGrvXtSkwkjLWRGYq6KxiElDFgU/6IuxUW7SyFabshYQ==",
       "requires": {
         "chalk": "^5.2.0",
         "columnify": "^1.6.0",
         "debug": "^4.3.4",
-        "enquirer": "git+https://git@github.com/starpit/enquirer.git#d4dec9ed10d498efeb401eb99517d64f345056d9",
+        "enquirer": "https://git@github.com/starpit/enquirer#d4dec9ed10d498efeb401eb99517d64f345056d9",
         "env-paths": "^2.2.1",
         "escalade": "^3.1.1",
         "expand-home-dir": "^0.0.3",
@@ -20030,27 +19938,19 @@
       },
       "dependencies": {
         "chalk": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-          "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="
+          "version": "5.2.0"
         },
         "cli-cursor": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-          "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
           "requires": {
             "restore-cursor": "^4.0.0"
           }
         },
         "entities": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-          "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
+          "version": "4.4.0"
         },
         "hast-util-raw": {
           "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-8.0.0.tgz",
-          "integrity": "sha512-bKbaUxMNLjZMMowgcrc4l3aQSPiMLiceZD+mp+AKF8Si0mtyR2DYVdxzS2XBxXYDeW/VvfZy40lNxHRiY6MMTg==",
           "requires": {
             "@types/hast": "^2.0.0",
             "extend": "^3.0.0",
@@ -20067,36 +19967,26 @@
           }
         },
         "is-interactive": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-          "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="
+          "version": "2.0.0"
         },
         "log-symbols": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
-          "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
           "requires": {
             "chalk": "^5.0.0",
             "is-unicode-supported": "^1.1.0"
           }
         },
         "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+          "version": "2.1.0"
         },
         "onetime": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
           "requires": {
             "mimic-fn": "^2.1.0"
           }
         },
         "ora": {
           "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/ora/-/ora-6.2.0.tgz",
-          "integrity": "sha512-c1qb/1rdE+EFDYiLXh10VY459uMh7DN9zlgd8mZJLoeiPpYllN8eAOiih2Rkah5ywxRm5tHN5C9zPheDq8d1MA==",
           "requires": {
             "chalk": "^5.0.0",
             "cli-cursor": "^4.0.0",
@@ -20111,16 +20001,12 @@
         },
         "parse5": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-          "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
           "requires": {
             "entities": "^4.4.0"
           }
         },
         "restore-cursor": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-          "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
           "requires": {
             "onetime": "^5.1.0",
             "signal-exit": "^3.0.2"
@@ -20128,8 +20014,6 @@
         },
         "strip-ansi": {
           "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
           "requires": {
             "ansi-regex": "^6.0.1"
           }
@@ -20152,8 +20036,6 @@
     },
     "make-fetch-happen": {
       "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-11.0.3.tgz",
-      "integrity": "sha512-oPLh5m10lRNNZDjJ2kP8UpboUx2uFXVaVweVe/lWut4iHWcQEmfqSVJt2ihZsFI8HbpwyyocaXbCAWf0g1ukIA==",
       "requires": {
         "agentkeepalive": "^4.2.1",
         "cacache": "^17.0.0",
@@ -20173,9 +20055,7 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "7.14.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-          "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA=="
+          "version": "7.14.1"
         }
       }
     },
@@ -20184,8 +20064,6 @@
     },
     "matcher": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -20194,8 +20072,6 @@
       "dependencies": {
         "escape-string-regexp": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "dev": true,
           "optional": true
         }
@@ -20231,8 +20107,6 @@
     },
     "mdast-util-find-and-replace": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
-      "integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
       "requires": {
         "@types/mdast": "^3.0.0",
         "escape-string-regexp": "^5.0.0",
@@ -20374,14 +20248,10 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true
     },
     "memfs": {
       "version": "3.4.13",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.13.tgz",
-      "integrity": "sha512-omTM41g3Skpvx5dSYeZIbXKcXoAVc/AoMNwn9TKx++L/gaen/+4TTttmu8ZSch5vfVJ8uJvGbroTsIlslRg6lg==",
       "dev": true,
       "requires": {
         "fs-monkey": "^1.0.3"
@@ -20389,8 +20259,6 @@
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
       "dev": true
     },
     "merge-stream": {
@@ -20401,8 +20269,6 @@
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true
     },
     "micromark": {
@@ -20691,8 +20557,6 @@
     },
     "mime": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true
     },
     "mime-db": {
@@ -20714,8 +20578,6 @@
     },
     "mini-css-extract-plugin": {
       "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.5.tgz",
-      "integrity": "sha512-9HaR++0mlgom81s95vvNjxkg52n2b5s//3ZTI1EtzFb98awsLSivs2LMsVqnQ3ay0PVhqWcGNyDaTE961FOcjQ==",
       "dev": true,
       "requires": {
         "schema-utils": "^4.0.0"
@@ -20765,8 +20627,6 @@
     },
     "minipass-fetch": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.1.tgz",
-      "integrity": "sha512-t9/wowtf7DYkwz8cfMSt0rMwiyNIBXf5CKZ3S5ZMqRqMYT0oLTp0x1WorMI9WTwvaPg21r1JbFxJMum8JrLGfw==",
       "requires": {
         "encoding": "^0.1.13",
         "minipass": "^4.0.0",
@@ -20863,8 +20723,6 @@
     },
     "multicast-dns": {
       "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
-      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
       "dev": true,
       "requires": {
         "dns-packet": "^5.2.2",
@@ -20976,16 +20834,12 @@
     },
     "node-emoji": {
       "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
-      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "requires": {
         "lodash": "^4.17.21"
       }
     },
     "node-forge": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "dev": true
     },
     "node-gyp-build": {
@@ -21066,14 +20920,10 @@
     },
     "obuf": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
     "on-finished": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "dev": true,
       "requires": {
         "ee-first": "1.1.1"
@@ -21081,8 +20931,6 @@
     },
     "on-headers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "dev": true
     },
     "once": {
@@ -21100,8 +20948,6 @@
     },
     "open": {
       "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "requires": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -21208,8 +21054,6 @@
     },
     "p-retry": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "dev": true,
       "requires": {
         "@types/retry": "0.12.0",
@@ -21218,8 +21062,6 @@
       "dependencies": {
         "retry": {
           "version": "0.13.1",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-          "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
           "dev": true
         }
       }
@@ -21282,8 +21124,6 @@
     },
     "parseurl": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true
     },
     "pascal-case": {
@@ -21293,6 +21133,11 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "patch-console": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-1.0.0.tgz",
+      "integrity": "sha512-nxl9nrnLQmh64iTzMfyylSlRozL7kAXIaxw1fVcLYdyhNkJCRUzirRZTikXGJsg+hc4fqpneTK6iU2H1Q8THSA=="
     },
     "path-browserify": {
       "version": "1.0.1",
@@ -21314,8 +21159,6 @@
     },
     "path-to-regexp": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
       "dev": true
     },
     "path-type": {
@@ -21334,8 +21177,6 @@
     },
     "pend": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
     },
     "picocolors": {
@@ -21392,8 +21233,6 @@
     },
     "playwright": {
       "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.31.0.tgz",
-      "integrity": "sha512-cFn1ie3bdYw/9/Ty3842CfPSRSy+ZWPjEhrxWgC+jL/CUjq5RKVJZwUbXV1UKBQU1Vo0NetsokXmk9EEZiqVHQ==",
       "dev": true,
       "requires": {
         "playwright-core": "1.31.0"
@@ -21401,8 +21240,6 @@
     },
     "playwright-core": {
       "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.0.tgz",
-      "integrity": "sha512-/KquBjS5DcASCh8cGeNVHuC0kyb7c9plKTwaKxgOGtxT7+DZO2fjmFvPDBSXslEIK5CeOO/2kk5rOCktFXKEdA==",
       "dev": true
     },
     "pluralize": {
@@ -21670,14 +21507,10 @@
     },
     "prettier": {
       "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true
     },
     "pretty-bytes": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.0.tgz",
-      "integrity": "sha512-Rk753HI8f4uivXi4ZCIYdhmG1V+WKzvRMg/X+M42a6t7D07RcmopXJMDNk6N++7Bl75URRGsb40ruvg7Hcp2wQ=="
+      "version": "6.1.0"
     },
     "pretty-error": {
       "version": "4.0.0",
@@ -21699,14 +21532,10 @@
     },
     "process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
     "progress": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "promise-inflight": {
@@ -21736,8 +21565,6 @@
     },
     "properties-parser": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/properties-parser/-/properties-parser-0.3.1.tgz",
-      "integrity": "sha512-AkSQxQAviJ89x4FIxOyHGfO3uund0gvYo7lfD0E+Gp7gFQKrTNgtoYQklu8EhrfHVZUzTwKGZx2r/KDSfnljcA==",
       "requires": {
         "string.prototype.codepointat": "^0.2.0"
       }
@@ -21747,8 +21574,6 @@
     },
     "proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "dev": true,
       "requires": {
         "forwarded": "0.2.0",
@@ -21757,8 +21582,6 @@
       "dependencies": {
         "ipaddr.js": {
           "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-          "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
           "dev": true
         }
       }
@@ -21794,8 +21617,6 @@
     },
     "qs": {
       "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
@@ -21828,14 +21649,10 @@
     },
     "range-parser": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true
     },
     "raw-body": {
       "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
       "dev": true,
       "requires": {
         "bytes": "3.1.2",
@@ -21846,14 +21663,10 @@
       "dependencies": {
         "bytes": {
           "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-          "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
           "dev": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -21886,6 +21699,15 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "react-devtools-core": {
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.27.4.tgz",
+      "integrity": "sha512-dvZjrAJjahd6NNl7dDwEk5TyHsWJxDpYL7VnD9jdEr98EEEsVhw9G8JDX54Nrb3XIIOBlJDpjo3AuBuychX9zg==",
+      "requires": {
+        "shell-quote": "^1.6.1",
+        "ws": "^7"
+      }
+    },
     "react-dom": {
       "version": "18.2.0",
       "requires": {
@@ -21910,8 +21732,6 @@
     },
     "react-markdown": {
       "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.5.tgz",
-      "integrity": "sha512-jGJolWWmOWAvzf+xMdB9zwStViODyyFQhNB/bwCerbBKmrTmgmA599CGiOlP58OId1IMoIRsA8UdI1Lod4zb5A==",
       "requires": {
         "@types/hast": "^2.0.0",
         "@types/prop-types": "^15.0.0",
@@ -21931,14 +21751,10 @@
       },
       "dependencies": {
         "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+          "version": "18.2.0"
         },
         "style-to-object": {
           "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.1.tgz",
-          "integrity": "sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==",
           "requires": {
             "inline-style-parser": "0.1.1"
           }
@@ -21974,8 +21790,6 @@
     },
     "rehype-minify-whitespace": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-5.0.1.tgz",
-      "integrity": "sha512-PPp4lWJiBPlePI/dv1BeYktbwkfgXkrK59MUa+tYbMPgleod+4DvFK2PLU0O0O60/xuhHfiR9GUIUlXTU8sRIQ==",
       "requires": {
         "@types/hast": "^2.0.0",
         "hast-util-embedded": "^2.0.0",
@@ -22032,8 +21846,6 @@
     },
     "remark-emoji": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/remark-emoji/-/remark-emoji-3.1.0.tgz",
-      "integrity": "sha512-KmjkU04niXFMn/H+SsPAGnXhsuq0gT/neIg1KRw8vUKZ/PNxpLDGmwVzx4a14OOd5GJ8rnCdh6DKXqHySkUHAQ==",
       "requires": {
         "emoticon": "^4.0.1",
         "mdast-util-find-and-replace": "^2.2.2",
@@ -22099,8 +21911,6 @@
     },
     "requires-port": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
     },
     "resolve": {
@@ -22141,19 +21951,16 @@
     },
     "restore-cursor": {
       "version": "3.1.0",
-      "dev": true,
       "requires": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       },
       "dependencies": {
         "mimic-fn": {
-          "version": "2.1.0",
-          "dev": true
+          "version": "2.1.0"
         },
         "onetime": {
           "version": "5.1.2",
-          "dev": true,
           "requires": {
             "mimic-fn": "^2.1.0"
           }
@@ -22186,8 +21993,6 @@
     },
     "roarr": {
       "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
-      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -22226,8 +22031,6 @@
     },
     "sass": {
       "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.60.0.tgz",
-      "integrity": "sha512-updbwW6fNb5gGm8qMXzVO7V4sWf7LMXnMly/JEyfbfERbVH46Fn6q02BX7/eHTdKpE7d+oTkMMQpFWNUMfFbgQ==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -22237,8 +22040,6 @@
     },
     "sass-loader": {
       "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.2.2.tgz",
-      "integrity": "sha512-nrIdVAAte3B9icfBiGWvmMhT/D+eCDwnk+yA7VE/76dp/WkHX+i44Q/pfo71NYbwj0Ap+PGsn0ekOuU1WFJ2AA==",
       "dev": true,
       "requires": {
         "klona": "^2.0.6",
@@ -22289,14 +22090,10 @@
     },
     "select-hose": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-      "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
       "dev": true
     },
     "selfsigned": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.1.1.tgz",
-      "integrity": "sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==",
       "dev": true,
       "requires": {
         "node-forge": "^1"
@@ -22308,15 +22105,11 @@
     },
     "semver-compare": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "dev": true,
       "optional": true
     },
     "send": {
       "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -22336,8 +22129,6 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -22345,30 +22136,22 @@
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
               "dev": true
             }
           }
         },
         "depd": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
           "dev": true
         },
         "ms": {
           "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         }
       }
     },
     "serialize-error": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -22377,8 +22160,6 @@
       "dependencies": {
         "type-fest": {
           "version": "0.13.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
           "dev": true,
           "optional": true
         }
@@ -22392,8 +22173,6 @@
     },
     "serve-index": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-      "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
@@ -22407,8 +22186,6 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -22416,8 +22193,6 @@
         },
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
           "dev": true,
           "requires": {
             "depd": "~1.1.2",
@@ -22428,34 +22203,24 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         },
         "setprototypeof": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
           "dev": true
         },
         "statuses": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-          "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
           "dev": true
         }
       }
     },
     "serve-static": {
       "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
       "dev": true,
       "requires": {
         "encodeurl": "~1.0.2",
@@ -22474,8 +22239,6 @@
     },
     "setprototypeof": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true
     },
     "sha.js": {
@@ -22509,13 +22272,10 @@
       "dev": true
     },
     "shell-escape": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/shell-escape/-/shell-escape-0.2.0.tgz",
-      "integrity": "sha512-uRRBT2MfEOyxuECseCZd28jC1AJ8hmqqneWQ4VWUTgCAFvb3wKU1jLqj6egC4Exrr88ogg3dp+zroH4wJuaXzw=="
+      "version": "0.2.0"
     },
     "shell-quote": {
-      "version": "1.7.4",
-      "dev": true
+      "version": "1.7.4"
     },
     "shelljs": {
       "version": "0.8.5",
@@ -22527,8 +22287,6 @@
     },
     "side-channel": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
@@ -22540,9 +22298,7 @@
       "version": "3.0.7"
     },
     "slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+      "version": "3.0.0"
     },
     "slice-ansi": {
       "version": "5.0.0",
@@ -22563,8 +22319,6 @@
     },
     "sockjs": {
       "version": "0.3.24",
-      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
-      "integrity": "sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==",
       "dev": true,
       "requires": {
         "faye-websocket": "^0.11.3",
@@ -22574,8 +22328,6 @@
       "dependencies": {
         "uuid": {
           "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
           "dev": true
         }
       }
@@ -22633,8 +22385,6 @@
     },
     "spdy": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
-      "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
@@ -22646,8 +22396,6 @@
     },
     "spdy-transport": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
-      "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
@@ -22669,15 +22417,11 @@
     },
     "sprintf-js": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
       "dev": true,
       "optional": true
     },
     "ssri": {
       "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.1.tgz",
-      "integrity": "sha512-WVy6di9DlPOeBWEjMScpNipeSX2jIZBGEn5Uuo8Q7aIuFEuDX0pw8RxcOjlD1TWP4obi24ki7m/13+nFpcbXrw==",
       "requires": {
         "minipass": "^4.0.0"
       }
@@ -22685,6 +22429,21 @@
     "stable": {
       "version": "0.1.8",
       "dev": true
+    },
+    "stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+        }
+      }
     },
     "static-eval": {
       "version": "2.0.2",
@@ -22694,22 +22453,16 @@
     },
     "statuses": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true
     },
     "stdin-discarder": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
-      "integrity": "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==",
       "requires": {
         "bl": "^5.0.0"
       },
       "dependencies": {
         "bl": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
-          "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
           "requires": {
             "buffer": "^6.0.3",
             "inherits": "^2.0.4",
@@ -22786,9 +22539,7 @@
       }
     },
     "string.prototype.codepointat": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
-      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg=="
+      "version": "0.2.1"
     },
     "stringify-entities": {
       "version": "4.0.3",
@@ -22832,8 +22583,6 @@
     },
     "sumchecker": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
-      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0"
@@ -22848,22 +22597,16 @@
     },
     "supports-hyperlinks": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
       "requires": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
       },
       "dependencies": {
         "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "version": "4.0.0"
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -22937,8 +22680,6 @@
     },
     "terminal-link": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-3.0.0.tgz",
-      "integrity": "sha512-flFL3m4wuixmf6IfhFJd1YPiLiMuxEc8uHRM1buzIeZPm22Au2pDqBJQgdo7n1WfPU1ONFGv7YDwpFBmHGF6lg==",
       "requires": {
         "ansi-escapes": "^5.0.0",
         "supports-hyperlinks": "^2.2.0"
@@ -22946,16 +22687,12 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
-          "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
           "requires": {
             "type-fest": "^1.0.2"
           }
         },
         "type-fest": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+          "version": "1.4.0"
         }
       }
     },
@@ -23020,8 +22757,6 @@
     },
     "thunky": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
-      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
     "timers-browserify": {
@@ -23055,8 +22790,6 @@
     },
     "to-vfile": {
       "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-7.2.4.tgz",
-      "integrity": "sha512-2eQ+rJ2qGbyw3senPI0qjuM7aut8IYXK6AEoOWb+fJx/mQYzviTckm1wDjq91QYHAPBTYzmdJXxMFA6Mk14mdw==",
       "requires": {
         "is-buffer": "^2.0.0",
         "vfile": "^5.1.0"
@@ -23064,8 +22797,6 @@
     },
     "toidentifier": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true
     },
     "tree-kill": {
@@ -23082,9 +22813,7 @@
       "version": "3.0.1"
     },
     "trim-trailing-lines": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
-      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg=="
+      "version": "2.1.0"
     },
     "trough": {
       "version": "2.1.0"
@@ -23126,13 +22855,10 @@
       }
     },
     "type-fest": {
-      "version": "0.21.3",
-      "dev": true
+      "version": "0.21.3"
     },
     "type-is": {
       "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
@@ -23141,8 +22867,6 @@
     },
     "typescript": {
       "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "underscore": {
@@ -23162,32 +22886,24 @@
     },
     "unique-filename": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
-      "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
       "requires": {
         "unique-slug": "^4.0.0"
       }
     },
     "unique-slug": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
-      "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
       "requires": {
         "imurmurhash": "^0.1.4"
       }
     },
     "unist-builder": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-3.0.1.tgz",
-      "integrity": "sha512-gnpOw7DIpCA0vpr6NqdPvTWnlPTApCTRzr+38E6hCWx3rz/cjo83SsKIlS1Z+L5ttScQ2AwutNnb8+tAvpb6qQ==",
       "requires": {
         "@types/unist": "^2.0.0"
       }
     },
     "unist-util-find-after": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-4.0.1.tgz",
-      "integrity": "sha512-QO/PuPMm2ERxC6vFXEPtmAutOopy5PknD+Oq64gGwxKtk4xwo9Z97t9Av1obPmGU0IyTa6EKYUfTrK2QJS3Ozw==",
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0"
@@ -23213,8 +22929,6 @@
     },
     "unist-util-visit": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
-      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0",
@@ -23223,8 +22937,6 @@
     },
     "unist-util-visit-parents": {
       "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
-      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0"
@@ -23235,8 +22947,6 @@
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true
     },
     "update-browserslist-db": {
@@ -23274,8 +22984,6 @@
     },
     "use-resize-observer": {
       "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-9.1.0.tgz",
-      "integrity": "sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==",
       "requires": {
         "@juggle/resize-observer": "^3.3.1"
       }
@@ -23300,8 +23008,6 @@
     },
     "utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true
     },
     "uuid": {
@@ -23318,14 +23024,10 @@
     },
     "vary": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true
     },
     "vfile": {
       "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
-      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
       "requires": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
@@ -23564,8 +23266,6 @@
     },
     "wbuf": {
       "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
-      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dev": true,
       "requires": {
         "minimalistic-assert": "^1.0.0"
@@ -23582,8 +23282,6 @@
     },
     "webpack": {
       "version": "5.77.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.77.0.tgz",
-      "integrity": "sha512-sbGNjBr5Ya5ss91yzjeJTLKyfiwo5C628AFjEa6WSXcZa4E+F57om3Cc8xLb1Jh0b243AWuSYRf3dn7HVeFQ9Q==",
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -23659,8 +23357,6 @@
     },
     "webpack-dev-middleware": {
       "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
       "dev": true,
       "requires": {
         "colorette": "^2.0.10",
@@ -23672,8 +23368,6 @@
     },
     "webpack-dev-server": {
       "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.13.1.tgz",
-      "integrity": "sha512-5tWg00bnWbYgkN+pd5yISQKDejRBYGEw15RaEEslH+zdbNDxxaZvEAO2WulaSaFKb5n3YG8JXsGaDsut1D0xdA==",
       "dev": true,
       "requires": {
         "@types/bonjour": "^3.5.9",
@@ -23710,8 +23404,6 @@
       "dependencies": {
         "ws": {
           "version": "8.13.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
           "dev": true,
           "requires": {}
         }
@@ -23727,8 +23419,6 @@
     },
     "webpack-shell-plugin-next": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/webpack-shell-plugin-next/-/webpack-shell-plugin-next-2.3.1.tgz",
-      "integrity": "sha512-+ozr/BcsuPh2R6j4oxmu9qJCInhhDCQ+Lb/sSUNHuXjoGj+myxxZyjucHze+K9dCoIo22gAoK1yuCP/gSnpUNg==",
       "dev": true,
       "requires": {}
     },
@@ -23737,8 +23427,6 @@
     },
     "websocket-driver": {
       "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
       "dev": true,
       "requires": {
         "http-parser-js": ">=0.5.1",
@@ -23748,8 +23436,6 @@
     },
     "websocket-extensions": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
-      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true
     },
     "which": {
@@ -23796,6 +23482,36 @@
         }
       }
     },
+    "widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "requires": {
+        "string-width": "^4.0.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        }
+      }
+    },
     "wildcard": {
       "version": "2.0.0",
       "dev": true
@@ -23804,9 +23520,7 @@
       "version": "1.2.3"
     },
     "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
+      "version": "1.0.0"
     },
     "wrap-ansi": {
       "version": "7.0.0",
@@ -23852,8 +23566,6 @@
     },
     "write-file-atomic": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.0.tgz",
-      "integrity": "sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==",
       "requires": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
@@ -23895,8 +23607,6 @@
     },
     "yargs": {
       "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "requires": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -23928,8 +23638,6 @@
     },
     "yauzl": {
       "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",
@@ -23946,6 +23654,14 @@
     "yocto-queue": {
       "version": "0.1.0",
       "dev": true
+    },
+    "yoga-layout-prebuilt": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yoga-layout-prebuilt/-/yoga-layout-prebuilt-1.10.0.tgz",
+      "integrity": "sha512-YnOmtSbv4MTf7RGJMK0FvZ+KD8OEe/J5BNnR0GHhD8J/XcG/Qvxgszm0Un6FTHWW4uHlTgP0IztiXQnGyIR45g==",
+      "requires": {
+        "@types/yoga-layout": "1.9.2"
+      }
     },
     "zip-webpack-plugin": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "@kui-shell/plugin-bash-like": "13.1.3-dev-20230329-123301",
     "@kui-shell/plugin-client-common": "13.1.3-dev-20230329-123301",
     "@kui-shell/plugin-codeflare": "file:./plugins/plugin-codeflare",
+    "@kui-shell/plugin-codeflare-dashboard": "file:./plugins/plugin-codeflare-dashboard",
     "@kui-shell/plugin-core-support": "13.1.3-dev-20230329-123301",
     "@kui-shell/plugin-electron-components": "13.1.3-dev-20230329-123301",
     "@kui-shell/plugin-kubectl": "13.1.3-dev-20230329-123301",

--- a/plugins/plugin-codeflare-dashboard/.gitignore
+++ b/plugins/plugin-codeflare-dashboard/.gitignore
@@ -1,0 +1,2 @@
+dist
+mdist

--- a/plugins/plugin-codeflare-dashboard/.npmignore
+++ b/plugins/plugin-codeflare-dashboard/.npmignore
@@ -1,0 +1,6 @@
+build
+src
+tests
+dist/test
+tsconfig*
+/*.tgz

--- a/plugins/plugin-codeflare-dashboard/package.json
+++ b/plugins/plugin-codeflare-dashboard/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@kui-shell/plugin-codeflare-dashboard",
+  "version": "0.0.1",
+  "description": "ML dashboarding",
+  "types": "./mdist/index.d.ts",
+  "module": "./mdist/index.js",
+  "main": "./mdist/index.js",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/IBM/kui#readme",
+  "bugs": {
+    "url": "https://github.com/IBM/kui/issues/new"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/IBM/kui.git"
+  },
+  "keywords": [
+    "kui",
+    "plugin"
+  ],
+  "private": true,
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@types/split2": "^3.2.1",
+    "react-devtools-core": "^4.27.2"
+  },
+  "dependencies": {
+    "@logdna/tail-file": "^3.0.1",
+    "chokidar": "^3.5.3",
+    "ink": "^3.2.0",
+    "madwizard": "^7.0.3",
+    "pretty-ms": "^7.0.1",
+    "strip-ansi": "6.0.0"
+  }
+}

--- a/plugins/plugin-codeflare-dashboard/src/components/Dashboard.tsx
+++ b/plugins/plugin-codeflare-dashboard/src/components/Dashboard.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2023 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+import { Box, Text, TextProps } from "ink"
+import type { Arguments } from "@kui-shell/core"
+
+type WorkerState = "Pending" | "Scheduled" | "Installing" | "Running" | "Failed" | "Success"
+
+type Props = unknown
+type State = {
+  workers: WorkerState[]
+}
+
+class Dashboard extends React.PureComponent<Props, State> {
+  public constructor(props: Props) {
+    super(props)
+
+    const styles = Object.keys(this.styleOf) as WorkerState[]
+    const randoState = () => styles[Math.round(Math.random() * styles.length) % styles.length]
+    this.state = {
+      workers: Array(50).fill(1).map(randoState),
+    }
+
+    setInterval(() => {
+      this.setState((curState) => {
+        const idx = Math.round(Math.random() * this.state.workers.length) % this.state.workers.length
+        const styles = Object.keys(this.styleOf)
+        const newState = styles[Math.round(Math.random() * styles.length) % styles.length]
+        return {
+          workers: [...curState.workers.slice(0, idx), newState as WorkerState, ...curState.workers.slice(idx + 1)],
+        }
+      })
+    }, 1000)
+  }
+
+  // private readonly sizes = ["▁▁", "▃▃", "▅▅", "▆▆", "██", "■■"]
+  // private readonly sizes = "■".repeat(5)
+  private readonly sizes = Array(5).fill("▇▇")
+  // private readonly sizes = "█".repeat(4)
+
+  private readonly styleOf: Record<WorkerState, TextProps> = {
+    Pending: { color: "gray", children: this.sizes[3] },
+    Scheduled: { color: "white", dimColor: true, children: this.sizes[3] },
+    // Pulling: { color: "yellow", dimColor: true, children: this.sizes[3] },
+    Installing: { color: "yellow", children: this.sizes[3] },
+    Running: { color: "cyan", children: this.sizes[4] },
+    Failed: { color: "red", children: this.sizes[4] },
+    Success: { color: "blue", children: this.sizes[4] },
+  }
+
+  private matrix(): WorkerState[][] {
+    const N = Math.ceil(Math.sqrt(this.state.workers.length))
+    const matrix = Array(N)
+    for (let i = 0; i < N; i++) {
+      matrix[i] = Array(N)
+      for (let j = 0; j < N; j++) {
+        matrix[i][j] = this.state.workers[i * N + j]
+      }
+    }
+    return matrix
+  }
+
+  private histo(): number[] {
+    const keys = Object.keys(this.styleOf)
+    const indexer = keys.reduce((M, worker, idx) => {
+      M[worker] = idx
+      return M
+    }, {} as Record<string, number>)
+
+    return this.state.workers.reduce((H, worker) => {
+      H[indexer[worker]]++
+      return H
+    }, Array(keys.length).fill(0))
+  }
+
+  public render() {
+    const M = this.matrix()
+    const H = this.histo()
+
+    return (
+      <Box flexDirection="column" margin={1}>
+        <Box>
+          {Object.keys(this.styleOf).map((_, idx) => (
+            <Box width="20%" borderStyle="singleDouble" marginRight={1} key={_}>
+              <Box flexDirection="column">
+                <Box>
+                  <Text color={this.styleOf[_ as WorkerState].color} bold inverse>
+                    {_}
+                  </Text>
+                </Box>
+                <Box>
+                  <Text>{H[idx]}</Text>
+                </Box>
+              </Box>
+            </Box>
+          ))}
+        </Box>
+
+        <Box marginTop={1} width={M.reduce((N, c) => (N += c.length), 0)} flexDirection="column">
+          {M.map((row, ridx) => (
+            <Box key={ridx}>
+              {row.map((worker, cidx) => (
+                <Text key={cidx} {...this.styleOf[worker]} />
+              ))}
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    )
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export default async function dashboard(args: Arguments) {
+  const { render } = await import("ink")
+  await render(<Dashboard />)
+  await new Promise(() => {}) // eslint-disable-line @typescript-eslint/no-empty-function
+  return true
+}

--- a/plugins/plugin-codeflare-dashboard/src/components/Dashboard/index.tsx
+++ b/plugins/plugin-codeflare-dashboard/src/components/Dashboard/index.tsx
@@ -1,0 +1,422 @@
+/*
+ * Copyright 2023 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+import prettyMillis from "pretty-ms"
+import { Box, BoxProps, Spacer, Text, TextProps } from "ink"
+
+export type Worker = {
+  /** Identifier of this worker */
+  name: string
+
+  /** Current metric value */
+  metric: string
+
+  /** Color for grid cell and legend */
+  style: TextProps
+
+  /** millis since epoch of the first update */
+  firstUpdate: number
+
+  /** millis since epoch of the last update */
+  lastUpdate: number
+}
+
+/** Updated info from controller */
+type UpdatePayload = {
+  /** Per-worker status info */
+  workers: Worker[]
+
+  /** Lines of raw output to be displayed */
+  lines?: { lines: string[]; idx: number; N: number }
+}
+
+/** Callback from controller when it has updated data */
+export type OnData = (payload: UpdatePayload) => void
+
+export type GridSpec = {
+  /** title of grid */
+  title: string
+
+  /** Names for distinct states */
+  states: { state: string; style: TextProps }[]
+
+  /** Init updater that returns a cancellation function */
+  initWatcher(cb: OnData): { quit: () => void }
+}
+
+type Props = {
+  /** CodeFlare Profile for this dashboard */
+  profile: string
+
+  /** Job ID that this dashboard visualizes */
+  jobId: string
+
+  /** Scale up the grid? [default: 1] */
+  scale?: number
+
+  grids: GridSpec[]
+}
+
+type State = {
+  /** millis since epoch of the first update */
+  firstUpdate: number
+
+  /** millis since epoch of the last update */
+  lastUpdate: number
+
+  /** iteration count to help us keep "last updated ago" UI fresh */
+  iter: number
+
+  /** interval to keep "last updated ago" UI fresh */
+  agoInterval: ReturnType<typeof setInterval>
+
+  /** Lines of raw output to be displayed */
+  lines: UpdatePayload["lines"]
+
+  /** Controller that allows us to shut down gracefully */
+  watchers: { quit: () => void }[]
+
+  /** Model of current workers */
+  workers: UpdatePayload["workers"][]
+}
+
+type GridProps = {
+  scale: Props["scale"]
+  title: Props["grids"][number]["title"]
+  states: Props["grids"][number]["states"]
+  workers: State["workers"][number]
+}
+
+class Grid extends React.PureComponent<GridProps> {
+  /** Chunk `A` into subarrays of at most length `N` */
+  private chunk<T>(A: T[], N: number): T[][] {
+    const matrix = Array(N).fill(undefined)
+    for (let i = 0; i < N; i++) {
+      matrix[i] = Array(N).fill(undefined)
+      for (let j = 0; j < N; j++) {
+        const a = A[i * N + j]
+        if (a !== undefined) {
+          matrix[i][j] = a
+        }
+      }
+    }
+
+    // leftover?
+    const lastIdx = N * N
+    if (lastIdx < A.length) {
+      const L: T[] = []
+      matrix.push(L)
+      for (let j = lastIdx; j < A.length; j++) {
+        L.push(A[j])
+      }
+    }
+
+    return matrix
+  }
+
+  // private readonly sizes = ["▁▁", "▃▃", "▅▅", "▆▆", "██", "■■"]
+
+  private readonly cell = "█▉"
+  private cellFor(props: TextProps): TextProps {
+    return Object.assign({ children: this.cell }, props)
+  }
+
+  private get emptyCell(): TextProps {
+    return this.cellFor({ color: "gray", dimColor: true })
+  }
+
+  /** @return current `Worker[]` model */
+  private get workers(): UpdatePayload["workers"] {
+    return this.props.workers || []
+  }
+
+  /** Zoom/Scale up the grid? */
+  private get scale() {
+    return Math.max(this.props.scale || 1, 1)
+  }
+
+  /**
+   * For visual clarity with a small number of workers, you may set a
+   * minimum length of grid sides (Note: it will be square, so this is
+   * just the length of a side in the grid/heat map).
+   */
+  private get minMatrixSize() {
+    return 2
+  }
+
+  private matrixModel(): Worker[][] {
+    const N = Math.max(this.minMatrixSize, Math.ceil(Math.sqrt(this.workers.length)))
+    return this.chunk(this.workers, N)
+  }
+
+  /** Histogram form of `this.workers` */
+  private histoModel(): number[] {
+    const keys = this.props.states
+    const indexer = keys.reduce((M, { state }, idx) => {
+      M[state] = idx
+      return M
+    }, {} as Record<string, number>)
+
+    return this.workers.reduce((H, worker) => {
+      H[indexer[worker.metric]]++
+      return H
+    }, Array(keys.length).fill(0))
+  }
+
+  /** @return legend UI */
+  private legend() {
+    const H = this.histoModel()
+    const outerBoxProps: BoxProps = {
+      marginRight: 1,
+      justifyContent: "flex-end",
+    }
+    const innerBoxProps: BoxProps = {
+      // flexDirection: "row", // values to the right of labels
+      flexDirection: "column", // values below labels
+      alignItems: "flex-end",
+    }
+    const valueProps = {}
+
+    // arrange into a kind of matrix with at most `k` labels per row
+    const k = 3 // TODO take into account width of screen
+    const A = this.chunk(this.props.states, k)
+    const C = this.chunk(H, k).filter(Boolean)
+
+    return (
+      <Box flexDirection="column">
+        {A.filter(Boolean).map((AA, ridx) => (
+          <Box key={ridx} flexDirection="row" justifyContent="space-around">
+            {AA.filter(Boolean).map((_, cidx) => (
+              <Box key={_.state} {...outerBoxProps}>
+                <Box {...innerBoxProps} marginLeft={1}>
+                  <Box>
+                    <Text {..._.style} bold>
+                      {_.state}
+                    </Text>
+                  </Box>
+
+                  <Box {...valueProps}>
+                    <Text {..._.style}>{C[ridx][cidx] /*.toString().padStart(maxLen)*/}</Text>
+                  </Box>
+                </Box>
+              </Box>
+            ))}
+          </Box>
+        ))}
+      </Box>
+    )
+  }
+
+  /** @return the UI for one row of the grid */
+  private gridRow(row: Worker[], ridx: number) {
+    return (
+      <Box key={ridx}>
+        {row.map((worker, cidx) => (
+          <Text key={cidx} {...(!worker ? this.emptyCell : this.cellFor(worker.style))} />
+        ))}
+      </Box>
+    )
+  }
+
+  /** @return grid UI */
+  private grid() {
+    const M = this.matrixModel()
+    return (
+      <Box flexDirection="column">
+        {M.map((row, ridx) =>
+          Array(this.scale)
+            .fill(0)
+            .map((_, sidx) => this.gridRow(row, this.scale * ridx + sidx))
+        )}
+      </Box>
+    )
+  }
+
+  private title() {
+    return <Text>{this.props.title}</Text>
+  }
+
+  public render() {
+    return (
+      <Box flexDirection="column" alignItems="center" justifyContent="center" paddingTop={1} paddingBottom={1}>
+        {this.title()}
+        {this.grid()}
+        <Box marginTop={1}>{this.legend()}</Box>
+      </Box>
+    )
+  }
+}
+
+export default class Dashboard extends React.PureComponent<Props, State> {
+  public componentDidMount() {
+    this.setState({
+      workers: [],
+      watchers: this.props.grids.map((props, gridIdx) =>
+        props.initWatcher((model: UpdatePayload) => this.onUpdate(gridIdx, model))
+      ),
+      agoInterval: setInterval(() => this.setState((curState) => ({ iter: (curState?.iter || 0) + 1 })), 5 * 1000),
+    })
+  }
+
+  public componentWillUnmount() {
+    if (this.state?.watchers) {
+      this.state.watchers.forEach((_) => _.quit())
+    }
+    if (this.state?.agoInterval) {
+      clearInterval(this.state.agoInterval)
+    }
+  }
+
+  /** We have received an update from `this.props.initWatcher` */
+  private readonly onUpdate = (gridIdx: number, model: UpdatePayload) => {
+    this.setState((curState) => ({
+      firstUpdate: (curState && curState.firstUpdate) || Date.now(), // TODO pull from the events
+      lastUpdate: Date.now(), // TODO pull from the events
+      lines: !model.lines || model.lines.N === 0 ? curState?.lines : model.lines,
+      workers: !curState?.workers
+        ? [model.workers]
+        : [...curState.workers.slice(0, gridIdx), model.workers, ...curState.workers.slice(gridIdx + 1)],
+    }))
+  }
+
+  /** @return current `lines` model */
+  private get lines(): UpdatePayload["lines"] {
+    return this.state?.lines
+  }
+
+  /** @return first update time */
+  private get firstUpdate() {
+    return this.state?.firstUpdate || Date.now()
+  }
+
+  /** @return last update time */
+  private get lastUpdate() {
+    return this.state?.lastUpdate || Date.now()
+  }
+
+  /** @return last update time delta */
+  private get lastUpdatedAgo() {
+    return Date.now() - this.lastUpdate
+  }
+
+  /** @return duration covered by this view */
+  private get duration() {
+    return this.lastUpdate - this.firstUpdate
+  }
+
+  private header() {
+    return (
+      <Box borderStyle="doubleSingle" flexDirection="column">
+        <Box>
+          <Text>
+            <Text color="blue" bold>
+              Profile{" "}
+            </Text>
+            {this.props.profile}
+          </Text>
+
+          <Spacer />
+
+          <Box marginLeft={1}>
+            <Text>
+              <Text color="blue" bold>
+                Duration{" "}
+              </Text>
+              {prettyMillis(this.duration, { compact: true }).padEnd(10)}
+            </Text>
+          </Box>
+        </Box>
+
+        <Box>
+          <Text>
+            <Text color="blue" bold>
+              {"Job".padStart("Profile".length)}{" "}
+            </Text>
+            {this.props.jobId}
+          </Text>
+
+          <Spacer />
+
+          <Box marginLeft={1}>
+            <Text>
+              <Text color="blue" bold>
+                Last updated{" "}
+              </Text>
+              {this.ago(this.lastUpdatedAgo).padEnd(10)}
+            </Text>
+          </Box>
+        </Box>
+      </Box>
+    )
+  }
+
+  private ago(millis: number) {
+    return prettyMillis(millis, { compact: true }) + " ago"
+  }
+
+  private agos(timestamp: string) {
+    return this.ago(Date.now() - new Date(timestamp).getTime())
+  }
+
+  private footer() {
+    if (!this.lines) {
+      return <React.Fragment />
+    } else {
+      const rows = []
+      for (let idx = this.lines.idx, n = 0; n < this.lines.N; idx = (idx + 1) % this.lines.lines.length, n++) {
+        const line = this.lines.lines[idx]
+          .replace(/(\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ)/, (_, timestamp) => this.agos(timestamp))
+          .replace(/pod\/torchx-\S+ /, "") // worker name in torchx
+          .replace(/pod\/ray-(head|worker)-\S+ /, "") // worker name in ray
+          .replace(/\* /, "") // wildcard worker name (codeflare)
+
+        // [2J is part of clear screen; we don't want those to flow through
+        // eslint-disable-next-line no-control-regex
+        rows.push(<Text key={line + "-" + n}>{line.replace(/\x1b\x5B\[2J/g, "")}</Text>)
+      }
+      return <React.Fragment>{rows}</React.Fragment>
+    }
+  }
+
+  private body() {
+    return (
+      <Box justifyContent="space-around">
+        {this.props.grids.map((props, idx) => (
+          <Box key={props.title} marginLeft={2}>
+            <Grid
+              key={props.title}
+              title={props.title}
+              scale={this.props.scale}
+              states={props.states}
+              workers={this.state?.workers[idx] || []}
+            />
+          </Box>
+        ))}
+      </Box>
+    )
+  }
+
+  public render() {
+    return (
+      <Box flexDirection="column">
+        {this.header()}
+        {this.body()}
+        {this.footer()}
+      </Box>
+    )
+  }
+}

--- a/plugins/plugin-codeflare-dashboard/src/controller/dashboard/db.tsx
+++ b/plugins/plugin-codeflare-dashboard/src/controller/dashboard/db.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react"
+
+import type Options from "./options.js"
+import Dashboard, { GridSpec } from "../../components/Dashboard/index.js"
+
+/** Wrap the `grids` in a `Dashboard` UI */
+export default function db(
+  profile: string,
+  jobId: string,
+  grids: null | GridSpec | GridSpec[],
+  opts: Pick<Options, "scale">
+) {
+  if (!grids || (Array.isArray(grids) && grids.length === 0)) {
+    return null
+  } else {
+    return (
+      <Dashboard profile={profile} jobId={jobId} scale={opts.scale} grids={Array.isArray(grids) ? grids : [grids]} />
+    )
+  }
+}

--- a/plugins/plugin-codeflare-dashboard/src/controller/dashboard/index.ts
+++ b/plugins/plugin-codeflare-dashboard/src/controller/dashboard/index.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2023 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Arguments } from "@kui-shell/core"
+
+import tailf from "./tailf.js"
+import dashboardUI from "./db.js"
+import status from "./status.js"
+import utilization from "./utilization.js"
+import { KindA, isValidKindA, validKinds } from "./kinds.js"
+import type { GridSpec } from "../../components/Dashboard/index.js"
+
+export type Options = Arguments["parsedOptions"] & {
+  s: number
+  scale: number
+
+  demo: boolean
+
+  p: string
+  profile: string
+  theme: string
+}
+
+/** Behave like top, where the screen is cleared just for this process */
+function enterAltBufferMode() {
+  console.log("\x1b[?1049h")
+}
+
+export function usage(cmd = "dashboard") {
+  return `Usage: codeflare ${cmd} ${validKinds().join("|")} [<jobId>|-N]`
+}
+
+async function lastNJob(profile: string, N: number) {
+  const [{ join }, { readdir, stat }, { Profiles }] = await Promise.all([
+    import("path"),
+    import("fs/promises"),
+    import("madwizard"),
+  ])
+
+  const dir = Profiles.guidebookJobDataPath({ profile })
+  const files = await readdir(dir)
+  if (files.length === 0) {
+    throw new Error("No jobs available")
+    return
+  }
+
+  const cTimes = await Promise.all(files.map((_) => stat(join(dir, _)).then((_) => _.ctime.getTime())))
+  const sorted = files.map((file, idx) => ({ file, lastM: cTimes[idx] })).sort((a, b) => b.lastM - a.lastM)
+
+  if (!sorted[N]) {
+    throw new Error("Specified historical job not available")
+  } else {
+    return sorted[N].file
+  }
+}
+
+export async function jobIdFrom(args: Arguments<Options>, cmd = "dashboard", offset = 2) {
+  const profile = args.parsedOptions.p || (await import("madwizard").then((_) => _.Profiles.lastUsed()))
+
+  const jobIdFromCommandLine = args.argvNoOptions[args.argvNoOptions.indexOf(cmd) + offset]
+  const jobId = /^-\d+$/.test(jobIdFromCommandLine)
+    ? await lastNJob(profile, -parseInt(jobIdFromCommandLine, 10))
+    : jobIdFromCommandLine === undefined
+    ? await lastNJob(profile, 0)
+    : jobIdFromCommandLine
+
+  return { jobId, profile }
+}
+
+export default async function dashboard(args: Arguments<Options>) {
+  const { theme } = args.parsedOptions
+
+  const { demo } = args.parsedOptions
+  const scale = args.parsedOptions.s || 1
+
+  const kind = args.argvNoOptions[args.argvNoOptions.indexOf("dashboard") + 1]
+  const { jobId, profile } = await jobIdFrom(args)
+
+  if (!isValidKindA(kind)) {
+    throw new Error(usage())
+  } else if (!jobId) {
+    throw new Error(usage())
+  }
+
+  const gridFor = async (kind: "status" | "cpu" | "memory"): Promise<GridSpec> => {
+    const tails = await tailf(kind, profile, jobId)
+    return kind === "status"
+      ? status(tails, { demo, theme, themeDefault: "patternfly" })
+      : kind === "cpu"
+      ? utilization(kind, tails, { demo, theme, themeDefault: "rain" })
+      : utilization(kind, tails, { demo, theme, themeDefault: "purple" })
+  }
+
+  const gridForA = async (kind: KindA): Promise<null | GridSpec | GridSpec[]> => {
+    if (kind === "all") {
+      const grids = await Promise.all([gridFor("status"), gridFor("cpu"), gridFor("memory")])
+      return grids.filter(Boolean)
+    } else if (kind === "status" || kind === "cpu" || kind === "memory") {
+      return gridFor(kind)
+    } else {
+      return null
+    }
+  }
+
+  const db = dashboardUI(profile, jobId, await gridForA(kind), { scale })
+
+  if (!db) {
+    throw new Error(usage())
+  } else {
+    const { render } = await import("ink")
+
+    if (process.env.ALT !== "false") {
+      enterAltBufferMode()
+    }
+
+    const { waitUntilExit } = await render(db)
+    await waitUntilExit()
+    return true
+  }
+}

--- a/plugins/plugin-codeflare-dashboard/src/controller/dashboard/kinds.ts
+++ b/plugins/plugin-codeflare-dashboard/src/controller/dashboard/kinds.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type Kind = "status" | "gpu" | "cpu" | "memory" | "logs"
+export type KindA = Kind | "all"
+export default Kind
+
+export const resourcePaths: Record<Kind, string[]> = {
+  status: [
+    "events/kubernetes.txt",
+    "events/job-status.txt",
+    "events/pods.txt",
+    "events/runtime-env-setup.txt",
+    "logs/job.txt",
+  ],
+  gpu: ["resources/gpu.txt"],
+  cpu: ["resources/pod-vmstat.txt"],
+  memory: ["resources/pod-memory.txt"],
+  logs: ["logs/job.txt"],
+}
+
+export function validKinds() {
+  return Object.keys(resourcePaths)
+}
+
+export function isValidKind(kind: string): kind is Kind {
+  return validKinds().includes(kind)
+}
+
+export function isValidKindA(kind: string): kind is KindA {
+  return isValidKind(kind) || kind === "all"
+}

--- a/plugins/plugin-codeflare-dashboard/src/controller/dashboard/options.ts
+++ b/plugins/plugin-codeflare-dashboard/src/controller/dashboard/options.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type Options = {
+  demo: boolean
+  scale: number
+  theme: string
+  themeDefault: string
+}
+
+export default Options
+
+export const flags = {
+  boolean: ["demo"],
+}

--- a/plugins/plugin-codeflare-dashboard/src/controller/dashboard/status.tsx
+++ b/plugins/plugin-codeflare-dashboard/src/controller/dashboard/status.tsx
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2023 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import stripAnsi from "strip-ansi"
+import type { TextProps } from "ink"
+
+import type { Tail } from "./tailf.js"
+import type Options from "./options.js"
+import { OnData, Worker, GridSpec } from "../../components/Dashboard/index.js"
+import { isValidStatusTheme, statusThemes } from "./themes/status.js"
+
+type WorkerState = "Queued" | "Provisioning" | "Initializing" | "Running" | "Success" | "Failed"
+
+const states: WorkerState[] = ["Queued", "Provisioning", "Initializing", "Running", "Success", "Failed"]
+
+const stateFor: Record<string, WorkerState> = {
+  Pending: "Queued",
+  Queued: "Queued",
+  Job_Pending: "Initializing", // this comes after the job is submitted, but probably preparing deps
+
+  ContainerCreating: "Provisioning",
+  SuccessfulCreate: "Provisioning",
+  AddedInterface: "Provisioning",
+  Created: "Provisioning",
+  Scheduled: "Provisioning",
+
+  Unhealthy: "Provisioning", // service not yet ready... Initializing?
+
+  Initializing: "Initializing",
+  Installing: "Initializing",
+  Pulling: "Initializing",
+  Pulled: "Initializing",
+
+  Started: "Initializing",
+  Workers_Running: "Initializing",
+
+  Job_Running: "Running",
+
+  Success: "Success",
+  Succeeded: "Success",
+
+  // ignore these
+  // Workers_Terminating: "Success",
+  // Workers_Killing: "Success",
+
+  Failed: "Failed",
+  FailedScheduling: "Failed",
+}
+
+/**
+ * Maintain a model of live data from a given set of file streams
+ * (`tails`), and pump it into the given `cb` callback.
+ *
+ */
+class Live {
+  /** Model of status per worker */
+  private readonly workers: Record<string, Worker> = {}
+
+  /** Number of lines of output to retain. TODO this depends on height of terminal? */
+  private static readonly nLines = 18
+
+  /** Model of the last `Live.nLines` lines of output */
+  private readonly lines: string[] = Array(Live.nLines).fill("")
+
+  /** Current insertion index into `this.lines` */
+  private linesInsertionIdx = 0
+
+  /** Current number of valid lines in `this.lines` */
+  private linesCount = 0
+
+  public constructor(private readonly tails: Promise<Tail>[], cb: OnData, styleOf: Record<WorkerState, TextProps>) {
+    tails.map((tailf) => {
+      tailf.then(({ stream }) => {
+        stream.on("data", (data) => {
+          if (data) {
+            const line = stripAnsi(data)
+            const cols = line.split(/\s+/)
+
+            const provider = !cols[0] ? undefined : cols[0].replace(/^\[/, "")
+            const key = !cols[1] ? undefined : cols[1].replace(/\]$/, "")
+            const fullKey = (provider || "") + "_" + (key || "")
+            const metric = !provider || !key ? undefined : stateFor[fullKey] || stateFor[key]
+            const name = cols[2] ? cols[2].trim() : undefined
+            const timestamp = this.asMillisSinceEpoch(cols[cols.length - 1])
+
+            if (!name || !timestamp) {
+              // console.error("Bad status record", line)
+              this.pushLineAndPublish(data, cb)
+              return
+            } else if (!metric) {
+              // ignoring this line
+              return
+            } else if (provider === "Workers" && (!/^pod\//.test(name) || /cleaner/.test(name))) {
+              // only track pod events, and ignore our custodial pods
+              return
+            } else {
+              const update = (name: string) => {
+                if (!this.workers[name]) {
+                  // never seen this named worker before
+                  this.workers[name] = {
+                    name,
+                    metric,
+                    firstUpdate: timestamp,
+                    lastUpdate: timestamp,
+                    style: styleOf[metric],
+                  }
+                } else if (this.workers[name].lastUpdate <= timestamp) {
+                  // we have seen it before, update the metric value and
+                  // timestamp; note that we only update the model if our
+                  // timestamp is after the lastUpdate for this worker
+                  this.workers[name].metric = metric
+                  this.workers[name].lastUpdate = timestamp
+                  this.workers[name].style = styleOf[metric]
+                } else {
+                  // out of date event, drop it
+                  return
+                }
+
+                // inform the UI that we have updates
+                cb({
+                  lines: this.pushLine(data),
+                  workers: Object.values(this.workers),
+                })
+              }
+
+              if (name === "*") {
+                // this event affects every worker
+                Object.keys(this.workers).forEach(update)
+              } else {
+                // this event affects a specific worker
+                update(name)
+              }
+            }
+          }
+        })
+      })
+    })
+  }
+
+  /** Add `line` to our circular buffer `this.lines` */
+  private pushLine(line: string) {
+    if (this.lines.includes(line)) {
+      // duplicate line
+      // the oldest is the one we are about to overwrite
+      let oldestIdx = this.linesInsertionIdx
+      if (this.lines[oldestIdx].length === 0) {
+        do {
+          oldestIdx = (oldestIdx + 1) % Live.nLines
+        } while (this.lines[oldestIdx].length === 0)
+      }
+      return { lines: this.lines, idx: oldestIdx, N: this.linesCount }
+    } else {
+      const idx = this.linesInsertionIdx
+      this.linesInsertionIdx = (this.linesInsertionIdx + 1) % Live.nLines
+
+      this.lines[idx] = line
+      this.linesCount = Math.min(this.lines.length, this.linesCount + 1)
+
+      // the oldest is the one we are about to overwrite
+      let oldestIdx = this.linesInsertionIdx
+      if (this.lines[oldestIdx].length === 0) {
+        do {
+          oldestIdx = (oldestIdx + 1) % Live.nLines
+        } while (this.lines[oldestIdx].length === 0)
+      }
+
+      return { lines: this.lines, idx: oldestIdx, N: this.linesCount }
+    }
+  }
+
+  /** `pushLine` and then pass the updated model to `cb` */
+  private pushLineAndPublish(line: string, cb: OnData) {
+    cb({ lines: this.pushLine(line), workers: Object.values(this.workers) })
+  }
+
+  private asMillisSinceEpoch(timestamp: string) {
+    try {
+      return new Date(timestamp).getTime()
+    } catch (err) {
+      // caller must check for undefined and handle error accordingly
+      return undefined
+    }
+  }
+
+  public async quit() {
+    await Promise.all(
+      this.tails.map(async (_) => {
+        try {
+          const tail = await _
+          return tail.quit()
+        } catch (err) {
+          // error initializing tailf, probably doesn't matter now that
+          // we're cleaning up
+        }
+      })
+    )
+  }
+}
+
+/** A blinking lights demo that pumps random data into the UI */
+class Demo {
+  private readonly interval: ReturnType<typeof setInterval>
+
+  public constructor(cb: OnData, styleOf: Record<WorkerState, TextProps>) {
+    const randoState = () => states[Math.round(Math.random() * states.length) % states.length]
+
+    // the model, filled initially with random data
+    let workers = Array(50)
+      .fill(1)
+      .map((_, idx) => {
+        const metric = randoState()
+        return { name: String(idx), metric, firstUpdate: Date.now(), lastUpdate: Date.now(), style: styleOf[metric] }
+      })
+
+    // initial callback to the UI
+    cb({ workers })
+
+    // periodically, change a random number of worker states, randomly
+    this.interval = setInterval(() => {
+      const nChanged = Math.max(1, Math.min(Math.floor(Math.random() * 8), workers.length))
+      for (let idx = 0; idx < nChanged; idx++) {
+        const metric = randoState()
+        const idx = Math.round(Math.random() * workers.length) % workers.length
+
+        workers = [
+          ...workers.slice(0, idx),
+          Object.assign(workers[idx], { metric, lastUpdate: Date.now(), style: styleOf[metric] }),
+          ...workers.slice(idx + 1),
+        ]
+      }
+
+      // periodic callback to the UI
+      cb({ workers })
+    }, 1000)
+  }
+
+  public quit() {
+    clearInterval(this.interval)
+  }
+}
+
+export default function statusDashboard(
+  tails: Promise<Tail>[],
+  opts: Pick<Options, "demo" | "theme" | "themeDefault">
+): GridSpec {
+  const { theme: themeS = opts.themeDefault } = opts
+  if (!isValidStatusTheme(themeS)) {
+    throw new Error("Invalid theme: " + themeS)
+  }
+
+  const theme = statusThemes[themeS]
+
+  const styleOf: Record<WorkerState, TextProps> = {
+    Queued: theme.gray,
+    Provisioning: theme.magenta,
+    Initializing: theme.lightBlue,
+    Running: theme.lightGreen,
+    Success: theme.green,
+    Failed: theme.red,
+  }
+
+  const initWatcher = (cb: OnData) => {
+    if (opts.demo) {
+      return new Demo(cb, styleOf)
+    } else {
+      return new Live(tails, cb, styleOf)
+    }
+  }
+
+  const styledStates = states.map((state) => ({ state, style: styleOf[state] }))
+  return { title: "Worker Status", initWatcher, states: styledStates }
+}

--- a/plugins/plugin-codeflare-dashboard/src/controller/dashboard/tailf.ts
+++ b/plugins/plugin-codeflare-dashboard/src/controller/dashboard/tailf.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { join } from "path"
+import split2 from "split2"
+import chokidar from "chokidar"
+import TailFile from "@logdna/tail-file"
+
+import Kind, { resourcePaths } from "./kinds.js"
+
+export type Tail = {
+  stream: import("stream").Readable
+  quit: TailFile["quit"]
+}
+
+function waitTillExists(filepath: string) {
+  const watcher = chokidar.watch(filepath)
+  return new Promise<void>((resolve, reject) => {
+    watcher.on("add", () => resolve())
+    watcher.on("error", reject)
+  })
+}
+
+async function initTail(filepath: string): Promise<Tail> {
+  await waitTillExists(filepath)
+
+  return new Promise<Tail>((resolve, reject) => {
+    const tail = new TailFile(filepath, {
+      startPos: 0,
+      pollFileIntervalMs: 500,
+    })
+
+    tail.once("tail_error", reject)
+    tail.start()
+
+    resolve({
+      stream: tail.pipe(split2()),
+      quit: tail.quit.bind(tail),
+    })
+  })
+}
+
+export async function pathsFor(kind: Kind, profile: string, jobId: string) {
+  const { Profiles } = await import("madwizard")
+  return resourcePaths[kind].map((resourcePath) =>
+    join(Profiles.guidebookJobDataPath({ profile }), jobId, resourcePath)
+  )
+}
+
+export default async function tailf(kind: Kind, profile: string, jobId: string): Promise<Promise<Tail>[]> {
+  return pathsFor(kind, profile, jobId).then((_) => _.map(initTail))
+}

--- a/plugins/plugin-codeflare-dashboard/src/controller/dashboard/themes/status.ts
+++ b/plugins/plugin-codeflare-dashboard/src/controller/dashboard/themes/status.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { TextProps } from "ink"
+
+type StatusThemeColor =
+  | "gray"
+  | "white"
+  | "lightYellow"
+  | "yellow"
+  | "lightBlue"
+  | "red"
+  | "blue"
+  | "magenta"
+  | "lightGreen"
+  | "green"
+
+export type StatusTheme = Record<StatusThemeColor, TextProps>
+
+export const defaultStatusTheme: StatusTheme = {
+  gray: { color: "gray" },
+  white: { color: "white", dimColor: true },
+  lightYellow: { color: "yellow", dimColor: true },
+  yellow: { color: "yellow" },
+  lightBlue: { color: "blue" },
+  red: { color: "red" },
+  blue: { color: "cyan" },
+  magenta: { color: "magenta" },
+  lightGreen: { color: "green", dimColor: true },
+  green: { color: "green" },
+}
+
+export const carbonStatusTheme: StatusTheme = {
+  gray: { color: "#8d8d8d" }, // gray50
+  white: { color: "#ff832b" }, // orange40
+  lightYellow: { color: "#fddc69" }, // yellow20
+  yellow: { color: "#8e6a00" }, // yellow60
+  lightBlue: { color: "#82cfff" }, // cyan30
+  red: { color: "#fa4d56" }, // red50
+  blue: { color: "#0072c3" }, // cyan50
+  magenta: { color: "#d4bbff" }, // purple30
+  lightGreen: { color: "#6fdc8c" }, // green30
+  green: { color: "#198038" }, // green60
+}
+
+export const patternflyStatusTheme: StatusTheme = {
+  gray: { color: "#B8BBBE" }, // black-400
+  white: { color: "#EC7A08" }, // orange-400
+  lightYellow: { color: "#F9E0A2" }, // gold-100
+  yellow: { color: "#C58C00" }, // gold-500
+  lightBlue: { color: "#35CAED" }, // light-blue-300
+  red: { color: "#C9190B" }, // red-100
+  blue: { color: "#2B9AF3" }, // blue-300
+  magenta: { color: "#A18FFF" }, // purple-300
+  lightGreen: { color: "#C8EB79" }, // light-green-200
+  green: { color: "#5BA352" }, // green-400
+}
+
+export const statusThemes = {
+  user: defaultStatusTheme,
+  carbon: carbonStatusTheme,
+  patternfly: patternflyStatusTheme,
+}
+
+export type ValidTheme = keyof typeof statusThemes
+
+export function isValidStatusTheme(theme: string): theme is ValidTheme {
+  return Object.keys(statusThemes).includes(theme)
+}

--- a/plugins/plugin-codeflare-dashboard/src/controller/dashboard/themes/utilization.ts
+++ b/plugins/plugin-codeflare-dashboard/src/controller/dashboard/themes/utilization.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @see https://colorbrewer2.org/#type=sequential&scheme=OrRd&n=6 */
+
+import type { TextProps } from "ink"
+
+export type Theme = [TextProps, TextProps, TextProps, TextProps, TextProps]
+
+export const red: Theme = [
+  { color: "#b30000" },
+  { color: "#e34a33" },
+  { color: "#fc8d59" },
+  { color: "#fdbb84" },
+  { color: "#fdd49e" },
+]
+
+export const purple: Theme = [
+  { color: "#810f7c" },
+  { color: "#8856a7" },
+  { color: "#8c96c6" },
+  { color: "#9ebcda" },
+  { color: "#bfd3e6" },
+]
+
+/*
+export const magenta: Theme = [
+  { color: "#" },
+  { color: "#" },
+  { color: "#" },
+  { color: "#" },
+  { color: "#" },
+]
+*/
+
+export const magenta: Theme = [
+  { color: "#7a0177" },
+  { color: "#c51b8a" },
+  { color: "#f768a1" },
+  { color: "#fa9fb5" },
+  { color: "#fcc5c0" },
+]
+
+export const green: Theme = [
+  { color: "#006837" },
+  { color: "#31a354" },
+  { color: "#78c679" },
+  { color: "#addd8e" },
+  { color: "#d9f0a3" },
+]
+
+export const blue: Theme = [
+  { color: "#045a8d" },
+  { color: "#2b8cbe" },
+  { color: "#74a9cf" },
+  { color: "#a6bddb" },
+  { color: "#d0d1e6" },
+]
+
+export const rain: Theme = [
+  { color: "#016c59" },
+  { color: "#1c9099" },
+  { color: "#67a9cf" },
+  { color: "#a6bddb" },
+  { color: "#d0d1e6" },
+]
+
+export const themes = {
+  red,
+  purple,
+  magenta,
+  blue,
+  green,
+  rain,
+}
+
+export type ValidTheme = keyof typeof themes
+
+export function isValidTheme(theme: string): theme is ValidTheme {
+  return Object.keys(themes).includes(theme)
+}

--- a/plugins/plugin-codeflare-dashboard/src/controller/dashboard/utilization.tsx
+++ b/plugins/plugin-codeflare-dashboard/src/controller/dashboard/utilization.tsx
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2023 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import stripAnsi from "strip-ansi"
+import type { TextProps } from "ink"
+
+import type { Tail } from "./tailf.js"
+import type Options from "./options.js"
+import { isValidTheme, themes } from "./themes/utilization.js"
+import { OnData, Worker, GridSpec } from "../../components/Dashboard/index.js"
+
+type WorkerState = "0-20%" | "20-40%" | "40-60%" | "60-80%" | "80-100%"
+
+const states: WorkerState[] = ["0-20%", "20-40%", "40-60%", "60-80%", "80-100%"]
+
+/**
+ * Maintain a model of live data from a given set of file streams
+ * (`tails`), and pump it into the given `cb` callback.
+ *
+ */
+class Live {
+  /** Model of status per worker */
+  private readonly workers: Record<string, Worker> = {}
+
+  private stateFor(util: string): WorkerState {
+    const percent = parseInt(util.replace(/%$/, ""), 10)
+    const bucketWidth = ~~(100 / states.length)
+    return states[~~(percent / bucketWidth)]
+  }
+
+  public constructor(private readonly tails: Promise<Tail>[], cb: OnData, styleOf: Record<WorkerState, TextProps>) {
+    tails.map((tailf) => {
+      tailf.then(({ stream }) => {
+        stream.on("data", (data) => {
+          if (data) {
+            const line = stripAnsi(data)
+            const cols = line.split(/\s+/)
+
+            const provider = !cols[0] ? undefined : cols[0].replace(/^\[/, "")
+            const key = !cols[2] ? undefined : cols[2].replace(/\]$/, "")
+            const metric = !provider || !key ? undefined : this.stateFor(key)
+            const name = cols[3] ? cols[3].trim() : undefined
+            const timestamp = this.asMillisSinceEpoch(cols[cols.length - 1])
+
+            if (!name || !timestamp) {
+              // console.error("Bad status record", line)
+              return
+            } else if (!metric) {
+              // ignoring this line
+              return
+            } else if (provider === "Workers" && (!/^pod\//.test(name) || /cleaner/.test(name))) {
+              // only track pod events, and ignore our custodial pods
+              return
+            } else {
+              const update = (name: string) => {
+                if (!this.workers[name]) {
+                  // never seen this named worker before
+                  this.workers[name] = {
+                    name,
+                    metric,
+                    firstUpdate: timestamp,
+                    lastUpdate: timestamp,
+                    style: styleOf[metric],
+                  }
+                } else if (this.workers[name].lastUpdate <= timestamp) {
+                  // we have seen it before, update the metric value and
+                  // timestamp; note that we only update the model if our
+                  // timestamp is after the lastUpdate for this worker
+                  this.workers[name].metric = metric
+                  this.workers[name].lastUpdate = timestamp
+                  this.workers[name].style = styleOf[metric]
+                } else {
+                  // out of date event, drop it
+                  return
+                }
+
+                // inform the UI that we have updates
+                cb({
+                  workers: Object.values(this.workers),
+                })
+              }
+
+              if (name === "*") {
+                // this event affects every worker
+                Object.keys(this.workers).forEach(update)
+              } else {
+                // this event affects a specific worker
+                update(name)
+              }
+            }
+          }
+        })
+      })
+    })
+  }
+
+  private asMillisSinceEpoch(timestamp: string) {
+    try {
+      return new Date(timestamp).getTime()
+    } catch (err) {
+      // caller must check for undefined and handle error accordingly
+      return undefined
+    }
+  }
+
+  public async quit() {
+    await Promise.all(
+      this.tails.map(async (_) => {
+        try {
+          const tail = await _
+          return tail.quit()
+        } catch (err) {
+          // error initializing tailf, probably doesn't matter now that
+          // we're cleaning up
+        }
+      })
+    )
+  }
+}
+
+/** A blinking lights demo that pumps random data into the UI */
+class Demo {
+  private readonly interval: ReturnType<typeof setInterval>
+
+  public constructor(cb: OnData, styleOf: Record<WorkerState, TextProps>) {
+    const randoState = () => states[Math.round(Math.random() * states.length) % states.length]
+
+    // the model, filled initially with random data
+    let workers = Array(50)
+      .fill(1)
+      .map((_, idx) => {
+        const metric = randoState()
+        return { name: String(idx), metric, firstUpdate: Date.now(), lastUpdate: Date.now(), style: styleOf[metric] }
+      })
+
+    // initial callback to the UI
+    cb({ workers })
+
+    // periodically, change a random number of worker states, randomly
+    this.interval = setInterval(() => {
+      const nChanged = Math.max(1, Math.min(Math.floor(Math.random() * 8), workers.length))
+      for (let idx = 0; idx < nChanged; idx++) {
+        const metric = randoState()
+        const idx = Math.round(Math.random() * workers.length) % workers.length
+
+        workers = [
+          ...workers.slice(0, idx),
+          Object.assign(workers[idx], { metric, lastUpdate: Date.now(), style: styleOf[metric] }),
+          ...workers.slice(idx + 1),
+        ]
+      }
+
+      // periodic callback to the UI
+      cb({ workers })
+    }, 1000)
+  }
+
+  public quit() {
+    clearInterval(this.interval)
+  }
+}
+
+function capitalize(str: string) {
+  return str[0].toUpperCase() + str.slice(1)
+}
+
+export default function utilizationDashboard(
+  kind: "cpu" | "memory",
+  tails: Promise<Tail>[],
+  opts: Pick<Options, "demo" | "theme" | "themeDefault">
+): GridSpec {
+  const { theme: themeS = opts.themeDefault } = opts
+  if (!isValidTheme(themeS)) {
+    throw new Error("Invalid theme: " + themeS)
+  }
+
+  const theme = themes[themeS]
+
+  const styleOf = theme.reduce((M, t, idx) => {
+    M[states[idx]] = t
+    return M
+  }, {} as Record<WorkerState, TextProps>)
+
+  const initWatcher = (cb: OnData) => {
+    if (opts.demo) {
+      return new Demo(cb, styleOf)
+    } else {
+      return new Live(tails, cb, styleOf)
+    }
+  }
+
+  const styledStates = states.map((state) => ({ state, style: styleOf[state] }))
+  return { title: capitalize(kind), initWatcher, states: styledStates }
+}

--- a/plugins/plugin-codeflare-dashboard/src/controller/dump.ts
+++ b/plugins/plugin-codeflare-dashboard/src/controller/dump.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Arguments } from "@kui-shell/core"
+
+import { pathsFor } from "./dashboard/tailf.js"
+import { isValidKind } from "./dashboard/kinds.js"
+import { Options, jobIdFrom, usage } from "./dashboard/index.js"
+
+export default async function dump(args: Arguments<Options>) {
+  const kind = args.argvNoOptions[args.argvNoOptions.indexOf("dump") + 1]
+  const { jobId, profile } = await jobIdFrom(args, "dump")
+
+  if (!isValidKind(kind)) {
+    throw new Error(usage("dump"))
+  } else if (!jobId) {
+    throw new Error(usage("dump"))
+  }
+
+  const { createReadStream } = await import("fs")
+  await Promise.all(
+    (
+      await pathsFor(kind, profile, jobId)
+    ).map(
+      (filepath) =>
+        new Promise((resolve, reject) => {
+          try {
+            const rs = createReadStream(filepath)
+            rs.on("close", resolve)
+            rs.pipe(process.stdout)
+          } catch (err) {
+            reject(err)
+          }
+        })
+    )
+  )
+
+  return true
+}

--- a/plugins/plugin-codeflare-dashboard/src/index.ts
+++ b/plugins/plugin-codeflare-dashboard/src/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2023 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/plugins/plugin-codeflare-dashboard/src/plugin.ts
+++ b/plugins/plugin-codeflare-dashboard/src/plugin.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 The Kubernetes Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KResponse, Registrar } from "@kui-shell/core"
+
+import { flags } from "./controller/dashboard/options.js"
+import type { Options as DashboardOptions } from "./controller/dashboard/index.js"
+
+/** Register Kui Commands */
+export default function registerCodeflareCommands(registrar: Registrar) {
+  registrar.listen<KResponse, DashboardOptions>(
+    "/codeflare/dashboard",
+    (args) => import("./controller/dashboard/index.js").then((_) => _.default(args)),
+    { flags }
+  )
+
+  registrar.listen<KResponse, DashboardOptions>("/codeflare/dump", (args) =>
+    import("./controller/dump.js").then((_) => _.default(args))
+  )
+}

--- a/plugins/plugin-codeflare-dashboard/tsconfig.json
+++ b/plugins/plugin-codeflare-dashboard/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../node_modules/@kui-shell/builder/tsconfig-base.json",
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "strict": true,
+    "composite": true,
+    "jsx": "react",
+    "outDir": "mdist",
+    "rootDir": "src"
+  }
+}

--- a/plugins/plugin-codeflare/package.json
+++ b/plugins/plugin-codeflare/package.json
@@ -30,7 +30,7 @@
     "@types/split2": "^3.2.1"
   },
   "dependencies": {
-    "@guidebooks/store": "^7.2.3",
+    "@guidebooks/store": "^7.2.8",
     "@logdna/tail-file": "^3.0.1",
     "@patternfly/react-charts": "^6.94.18",
     "@patternfly/react-core": "^4.276.6",

--- a/plugins/plugin-codeflare/src/controller/index.ts
+++ b/plugins/plugin-codeflare/src/controller/index.ts
@@ -22,7 +22,7 @@ import { width, height } from "@kui-shell/client/config.d/style.json"
 import tailf from "./tailf"
 import charts from "./charts"
 import events from "./events"
-import dashboard from "./dashboard"
+// import dashboard from "./dashboard"
 import description from "./description"
 import { LogsOptions, logsFlags } from "./logs"
 import { Options as AttachOptions } from "./attach"
@@ -30,7 +30,6 @@ import { Options as AttachOptions } from "./attach"
 function help() {
   return `Usage:
 codeflare [run] [<task>] [-s /path/to/store] [-u]
-codeflare dashboard /path/to/logdir
 codeflare chart gpu /path/to/logdir`
 }
 
@@ -39,7 +38,7 @@ export default function registerCodeflareCommands(registrar: Registrar) {
   tailf(registrar)
   charts(registrar)
   events(registrar)
-  dashboard(registrar)
+  // dashboard(registrar)
   description(registrar)
   registrar.listen("/help", help)
 

--- a/tests/kind/profiles/non-gpu1/mcad-coscheduler.arm64
+++ b/tests/kind/profiles/non-gpu1/mcad-coscheduler.arm64
@@ -15,10 +15,10 @@
     "kubernetes/choose/secret/image-pull": "No secret needed, since my image is public",
     "s3/choose/bucket/maybe": "My data is not stored in S3",
     "ml/ray/start/resources": {
-      "Number of Workers": 1,
-      "CPUs per worker": "200m",
+      "Number of Workers": 0,
+      "CPUs per worker": "2",
       "GPUs per worker": 0,
-      "Memory per worker": "1.25Gi",
+      "Memory per worker": "2.5Gi",
       "Ephemeral Storage per worker": "5Gi"
     },
     "kubernetes/context": "kind-codeflare-test",

--- a/tests/kind/profiles/non-gpu1/mcad-coscheduler.x86_64
+++ b/tests/kind/profiles/non-gpu1/mcad-coscheduler.x86_64
@@ -15,10 +15,10 @@
     "kubernetes/choose/secret/image-pull": "No secret needed, since my image is public",
     "s3/choose/bucket/maybe": "My data is not stored in S3",
     "ml/ray/start/resources": {
-      "Number of Workers": 1,
-      "CPUs per worker": "200m",
+      "Number of Workers": 0,
+      "CPUs per worker": "300m",
       "GPUs per worker": 0,
-      "Memory per worker": "1.25Gi",
+      "Memory per worker": "2.5Gi",
       "Ephemeral Storage per worker": "5Gi"
     },
     "kubernetes/context": "kind-codeflare-test",

--- a/tests/kind/profiles/non-gpu1/mcad-default.arm64
+++ b/tests/kind/profiles/non-gpu1/mcad-default.arm64
@@ -14,7 +14,7 @@
     "ml/codeflare/training/byoc/form": "{\"Path to source\":\"$PWD/tests/kind/inputs/qiskit\",\"Base image\":\"rayproject/ray:2.3.0-py38-aarch64\",\"Command line prefix\":\"python3 main.py\"}",
     "kubernetes/choose/secret/image-pull": "No secret needed, since my image is public",
     "s3/choose/bucket/maybe": "My data is not stored in S3",
-    "ml/ray/start/resources": "{\"Number of Workers\":1,\"CPUs per worker\":\"200m\",\"GPUs per worker\":0,\"Memory per worker\":\"1.25Gi\",\"Ephemeral Storage per worker\":\"5Gi\"}",
+    "ml/ray/start/resources": "{\"Number of Workers\":0,\"CPUs per worker\":\"2\",\"GPUs per worker\":0,\"Memory per worker\":\"2.5Gi\",\"Ephemeral Storage per worker\":\"5Gi\"}",
     "kubernetes/context": "kind-codeflare-test",
     "kubernetes/choose/ns": "default",
     "ml/ray/storage/s3/maybe": "My code does not use Ray Workflows",

--- a/tests/kind/profiles/non-gpu1/mcad-default.x86_64
+++ b/tests/kind/profiles/non-gpu1/mcad-default.x86_64
@@ -14,7 +14,7 @@
     "ml/codeflare/training/byoc/form": "{\"Path to source\":\"$PWD/tests/kind/inputs/qiskit\",\"Base image\":\"rayproject/ray:2.1.0-py38\",\"Command line prefix\":\"python3 main.py\"}",
     "kubernetes/choose/secret/image-pull": "No secret needed, since my image is public",
     "s3/choose/bucket/maybe": "My data is not stored in S3",
-    "ml/ray/start/resources": "{\"Number of Workers\":1,\"CPUs per worker\":\"200m\",\"GPUs per worker\":0,\"Memory per worker\":\"1.25Gi\",\"Ephemeral Storage per worker\":\"5Gi\"}",
+    "ml/ray/start/resources": "{\"Number of Workers\":0,\"CPUs per worker\":\"300m\",\"GPUs per worker\":0,\"Memory per worker\":\"2.5Gi\",\"Ephemeral Storage per worker\":\"5Gi\"}",
     "kubernetes/context": "kind-codeflare-test",
     "kubernetes/choose/ns": "default",
     "ml/ray/storage/s3/maybe": "My code does not use Ray Workflows",

--- a/tests/kind/profiles/non-gpu1/mcad-preinstalled.arm64
+++ b/tests/kind/profiles/non-gpu1/mcad-preinstalled.arm64
@@ -15,10 +15,10 @@
     "kubernetes/choose/secret/image-pull": "No secret needed, since my image is public",
     "s3/choose/bucket/maybe": "My data is not stored in S3",
     "ml/ray/start/resources": {
-      "Number of Workers": 1,
-      "CPUs per worker": "200m",
+      "Number of Workers": 0,
+      "CPUs per worker": "2",
       "GPUs per worker": 0,
-      "Memory per worker": "1.25Gi",
+      "Memory per worker": "2.5Gi",
       "Ephemeral Storage per worker": "5Gi"
     },
     "kubernetes/context": "kind-codeflare-test",

--- a/tests/kind/profiles/non-gpu1/mcad-preinstalled.x86_64
+++ b/tests/kind/profiles/non-gpu1/mcad-preinstalled.x86_64
@@ -15,10 +15,10 @@
     "kubernetes/choose/secret/image-pull": "No secret needed, since my image is public",
     "s3/choose/bucket/maybe": "My data is not stored in S3",
     "ml/ray/start/resources": {
-      "Number of Workers": 1,
-      "CPUs per worker": "200m",
+      "Number of Workers": 0,
+      "CPUs per worker": "300m",
       "GPUs per worker": 0,
-      "Memory per worker": "1.25Gi",
+      "Memory per worker": "2.5Gi",
       "Ephemeral Storage per worker": "5Gi"
     },
     "kubernetes/context": "kind-codeflare-test",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
 {
   "extends": "./node_modules/@kui-shell/builder/tsconfig-base.json",
-  "references": [{ "path": "./plugins/plugin-codeflare" }, { "path": "./plugins/plugin-client-default" }]
+  "references": [
+    { "path": "./plugins/plugin-codeflare-dashboard" },
+    { "path": "./plugins/plugin-codeflare" },
+    { "path": "./plugins/plugin-client-default" }
+  ]
 }


### PR DESCRIPTION
## `codeflare dashboard` command

```shell
codeflare dashboard all|cpu|memory|status [jobId|-N]
```

if the last argument (jobId) is not supplied, the latest one in the given profile (`-p/--profile`) will be used. This is equivalent to supplying `-1` for the jobId positional; more generally, `-2` will fetch the penultimate, and `-N` will use the Nth-last job to be run in the profile.

you can get such a demo mode by running `codeflare dashboard all --demo`

<img width="971" alt="codeflare dashboard" src="https://user-images.githubusercontent.com/4741620/228954108-019c9b2c-8183-4eec-ba82-084ea0d447e4.png">


### Limitations

- this currently assumes that the aggregator is already running against the job
- no gpu metrics, yet

## `codeflare dump` command

This also adds some helpers:

```
codeflare dump logs|cpu|gpu|memory|status [jobId|-N]
```

which will dump out the raw logs, cpu stats, etc. the `jobId|-N` positional has the same interpretation as above.