### PR TITLE
fix: support arranging dashboard grids into rows

### DIFF
--- a/plugins/plugin-codeflare-dashboard/src/controller/dashboard/db.tsx
+++ b/plugins/plugin-codeflare-dashboard/src/controller/dashboard/db.tsx
@@ -23,7 +23,7 @@ import Dashboard, { GridSpec } from "../../components/Dashboard/index.js"
 export default function db(
   profile: string,
   jobId: string,
-  grids: null | GridSpec | GridSpec[],
+  grids: null | GridSpec | (null | GridSpec)[],
   opts: Pick<Options, "scale">
 ) {
   if (!grids || (Array.isArray(grids) && grids.length === 0)) {

--- a/plugins/plugin-codeflare-dashboard/src/controller/dashboard/index.ts
+++ b/plugins/plugin-codeflare-dashboard/src/controller/dashboard/index.ts
@@ -103,16 +103,16 @@ export default async function dashboard(args: Arguments<Options>, cmd: "db" | "d
       : utilization(kind, tails, { demo, theme })
   }
 
-  const gridForA = async (kind: KindA): Promise<null | GridSpec | GridSpec[]> => {
+  const gridForA = async (kind: KindA): Promise<null | GridSpec | (null | GridSpec)[]> => {
     if (kind === "all") {
-      const grids = await Promise.all([
+      return Promise.all([
         gridFor("status"),
+        null, // newline
         gridFor("cpu%"),
         gridFor("mem%"),
         gridFor("gpu%"),
         gridFor("gpumem%"),
       ])
-      return grids.filter(Boolean)
     } else if (isSupportedGrid(kind)) {
       return gridFor(kind)
     } else {

--- a/plugins/plugin-codeflare-dashboard/src/controller/dashboard/utilization.tsx
+++ b/plugins/plugin-codeflare-dashboard/src/controller/dashboard/utilization.tsx
@@ -24,9 +24,14 @@ import { isValidTheme, themes } from "./themes/utilization.js"
 import { OnData, Worker, GridSpec } from "../../components/Dashboard/index.js"
 import { SupportedUtilizationGrid, defaultUtilizationThemes, providerFor } from "./grids.js"
 
-type WorkerState = "<20%" | "<40%" | "<60%" | "<80%" | "<100%"
+/**
+ * The discrete/quantized utilization states. Note: this currently is
+ * assumed to be parallel to the ./themes/utilization.ts arrays.
+ */
+const states = ["<20%", "<40%", "<60%", "<80%", "<100%"]
 
-const states: WorkerState[] = ["<20%", "<40%", "<60%", "<80%", "<100%"]
+/** Type declaration for quantized utilization states */
+type WorkerState = (typeof states)[number]
 
 /**
  * Maintain a model of live data from a given set of file streams
@@ -40,7 +45,8 @@ class Live {
   private stateFor(util: string): WorkerState {
     const percent = parseInt(util.replace(/%$/, ""), 10)
     const bucketWidth = ~~(100 / states.length)
-    return states[Math.min(~~(percent / bucketWidth), states.length - 1)]
+    const bucketIdx = Math.min(~~(percent / bucketWidth), states.length - 1)
+    return states[bucketIdx]
   }
 
   public constructor(


### PR DESCRIPTION
the `<Dashboard/>` component now supports `null` slots which mark row breaks in the grid-of-grids layout

```
[
        gridFor("status"),
        null, // newline
        gridFor("cpu%"),
        gridFor("mem%"),
        gridFor("gpu%"),
        gridFor("gpumem%"),
      ]
```

<img width="933" alt="Screenshot 2023-04-01 at 1 27 33 PM" src="https://user-images.githubusercontent.com/4741620/229305724-ea0ca364-9bfe-48be-9e46-84727b3d17a2.png">
