### PR TITLE
fix: use a priority heap to choose most important events to display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1891,6 +1891,12 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/heap": {
+      "version": "0.2.31",
+      "resolved": "https://registry.npmjs.org/@types/heap/-/heap-0.2.31.tgz",
+      "integrity": "sha512-cKL2veQoMEQGGSib6GTq7Of6mAX1e6gH/7F9ddE4+qsga/RRK/ThAkZcKF/i1yVc30ZxlY2r6vZ74NZNtAA0Yw==",
+      "dev": true
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "dev": true,
@@ -14644,12 +14650,14 @@
       "dependencies": {
         "@logdna/tail-file": "^3.0.1",
         "chokidar": "^3.5.3",
+        "heap": "^0.2.7",
         "ink": "^3.2.0",
         "madwizard": "^8.0.3",
         "pretty-ms": "^7.0.1",
         "strip-ansi": "6.0.0"
       },
       "devDependencies": {
+        "@types/heap": "^0.2.31",
         "@types/split2": "^3.2.1",
         "react-devtools-core": "^4.27.4"
       }
@@ -15560,8 +15568,10 @@
       "version": "file:plugins/plugin-codeflare-dashboard",
       "requires": {
         "@logdna/tail-file": "^3.0.1",
+        "@types/heap": "^0.2.31",
         "@types/split2": "^3.2.1",
         "chokidar": "^3.5.3",
+        "heap": "^0.2.7",
         "ink": "^3.2.0",
         "madwizard": "^8.0.3",
         "pretty-ms": "^7.0.1",
@@ -16047,6 +16057,12 @@
       "requires": {
         "@types/unist": "*"
       }
+    },
+    "@types/heap": {
+      "version": "0.2.31",
+      "resolved": "https://registry.npmjs.org/@types/heap/-/heap-0.2.31.tgz",
+      "integrity": "sha512-cKL2veQoMEQGGSib6GTq7Of6mAX1e6gH/7F9ddE4+qsga/RRK/ThAkZcKF/i1yVc30ZxlY2r6vZ74NZNtAA0Yw==",
+      "dev": true
     },
     "@types/html-minifier-terser": {
       "version": "6.1.0",

--- a/plugins/plugin-codeflare-dashboard/package.json
+++ b/plugins/plugin-codeflare-dashboard/package.json
@@ -23,12 +23,14 @@
     "access": "public"
   },
   "devDependencies": {
+    "@types/heap": "^0.2.31",
     "@types/split2": "^3.2.1",
     "react-devtools-core": "^4.27.4"
   },
   "dependencies": {
     "@logdna/tail-file": "^3.0.1",
     "chokidar": "^3.5.3",
+    "heap": "^0.2.7",
     "ink": "^3.2.0",
     "madwizard": "^8.0.3",
     "pretty-ms": "^7.0.1",

--- a/plugins/plugin-codeflare-dashboard/src/components/Dashboard/index.tsx
+++ b/plugins/plugin-codeflare-dashboard/src/components/Dashboard/index.tsx
@@ -86,7 +86,7 @@ export default class Dashboard extends React.PureComponent<Props, State> {
     this.setState((curState) => ({
       firstUpdate: (curState && curState.firstUpdate) || Date.now(), // TODO pull from the events
       lastUpdate: Date.now(), // TODO pull from the events
-      lines: !model.lines || model.lines.N === 0 ? curState?.lines : model.lines,
+      lines: !model.lines || model.lines.length === 0 ? curState?.lines : model.lines,
       workers: !curState?.workers
         ? [model.workers]
         : [...curState.workers.slice(0, gridIdx), model.workers, ...curState.workers.slice(gridIdx + 1)],
@@ -168,26 +168,26 @@ export default class Dashboard extends React.PureComponent<Props, State> {
     return prettyMillis(millis, { compact: true }) + " ago"
   }
 
-  private agos(timestamp: string) {
-    return this.ago(Date.now() - new Date(timestamp).getTime())
+  private agos(millis: number) {
+    return this.ago(Date.now() - millis)
   }
 
   private footer() {
     if (!this.lines) {
       return <React.Fragment />
     } else {
-      const rows = []
-      for (let idx = this.lines.idx, n = 0; n < this.lines.N; idx = (idx + 1) % this.lines.lines.length, n++) {
-        const line = this.lines.lines[idx]
-          .replace(/(\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ)/, (_, timestamp) => this.agos(timestamp))
-          .replace(/pod\/torchx-\S+ /, "") // worker name in torchx
-          .replace(/pod\/ray-(head|worker)-\S+ /, "") // worker name in ray
-          .replace(/\* /, "") // wildcard worker name (codeflare)
+      const rows = this.lines.map(({ line, timestamp }) => {
+        const txt = line.replace("{timestamp}", () => this.agos(timestamp))
+        //          .replace(/pod\/torchx-\S+ /, "") // worker name in torchx
+        //          .replace(/pod\/ray-(head|worker)-\S+ /, "") // worker name in ray
+        //          .replace(/\* /, "") // wildcard worker name (codeflare)
+        //          .replace(/\x1b\x5B\[2J/g, "")
+        // TODO timestamp
 
         // [2J is part of clear screen; we don't want those to flow through
         // eslint-disable-next-line no-control-regex
-        rows.push(<Text key={line + "-" + n}>{line.replace(/\x1b\x5B\[2J/g, "")}</Text>)
-      }
+        return <Text key={txt}>{txt}</Text>
+      })
       return (
         <Box marginTop={1} flexDirection="column">
           {rows}

--- a/plugins/plugin-codeflare-dashboard/src/components/Dashboard/types.ts
+++ b/plugins/plugin-codeflare-dashboard/src/components/Dashboard/types.ts
@@ -39,7 +39,7 @@ export type UpdatePayload = {
   workers: Worker[]
 
   /** Lines of raw output to be displayed */
-  lines?: { lines: string[]; idx: number; N: number }
+  lines?: { line: string; timestamp: number }[]
 }
 
 /** Callback from controller when it has updated data */

--- a/plugins/plugin-codeflare-dashboard/src/controller/dashboard/status/states.ts
+++ b/plugins/plugin-codeflare-dashboard/src/controller/dashboard/status/states.ts
@@ -19,6 +19,16 @@ export const states = ["Queued", "Provisioning", "Initializing", "Running", "Suc
 /** Type declaration for quantized utilization states */
 export type WorkerState = (typeof states)[number]
 
+/** Lower means more important */
+export const rankFor: Record<WorkerState, number> = {
+  Queued: 3,
+  Provisioning: 1,
+  Initializing: 2,
+  Running: 1,
+  Success: 0,
+  Failed: 0,
+}
+
 export const stateFor: Record<string, WorkerState> = {
   Pending: "Queued",
   Queued: "Queued",
@@ -32,9 +42,9 @@ export const stateFor: Record<string, WorkerState> = {
 
   Unhealthy: "Provisioning", // service not yet ready... Initializing?
 
-  Initializing: "Initializing",
-  Installing: "Initializing",
-  Pulling: "Initializing",
+  Initializing: "Provisioining",
+  Installing: "Provisioining",
+  Pulling: "Provisioining",
   Pulled: "Initializing",
 
   Started: "Initializing",

--- a/plugins/plugin-codeflare-dashboard/src/controller/env.ts
+++ b/plugins/plugin-codeflare-dashboard/src/controller/env.ts
@@ -48,10 +48,14 @@ export async function getJobEnv(profile: string, jobId: string): Promise<Record<
 }
 
 export async function numGpus(profile: string, jobId: string): Promise<number> {
-  const env = await getJobEnv(profile, jobId)
+  try {
+    const env = await getJobEnv(profile, jobId)
 
-  const raw = env["NUM_GPUS"]
-  return typeof raw === "number" ? raw : typeof raw === "string" ? parseInt(raw, 10) : 0
+    const raw = env["NUM_GPUS"]
+    return typeof raw === "number" ? raw : typeof raw === "string" ? parseInt(raw, 10) : 0
+  } catch (err) {
+    return 0
+  }
 }
 
 export async function usesGpus(profile: string, jobId: string): Promise<boolean> {


### PR DESCRIPTION
e.g. if we are limited in vertical space, prefer to show pods still Pulling images over pods that have announced they are done and Pulled also this improves the display of duplicate lines, rather just updating the timestamp