### PR TITLE
fix: bump store to pick up relpath and macos 3.9.6 fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -932,9 +932,9 @@
       "license": "MIT"
     },
     "node_modules/@guidebooks/store": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.4.6.tgz",
-      "integrity": "sha512-z7+MRfAhTt7bA4GpAX10tAYPG3EFyqQ8ZsKcxiuu85XuVlyf5tHs8kEA4ep9g+tWbrEudv6BrJSxvDHx4kFYLA=="
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.4.7.tgz",
+      "integrity": "sha512-4jD5koq/M99iY8xJkIlfINdMaHwxcvYdJ2OXGx5vnJ5DBr9WISJMNNbtKR42i0iNgU6kjYB2iBOLqSblbVV2ig=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -14621,7 +14621,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^7.4.6",
+        "@guidebooks/store": "^7.4.7",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.18",
         "@patternfly/react-core": "^4.276.6",
@@ -15288,9 +15288,9 @@
       "dev": true
     },
     "@guidebooks/store": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.4.6.tgz",
-      "integrity": "sha512-z7+MRfAhTt7bA4GpAX10tAYPG3EFyqQ8ZsKcxiuu85XuVlyf5tHs8kEA4ep9g+tWbrEudv6BrJSxvDHx4kFYLA=="
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.4.7.tgz",
+      "integrity": "sha512-4jD5koq/M99iY8xJkIlfINdMaHwxcvYdJ2OXGx5vnJ5DBr9WISJMNNbtKR42i0iNgU6kjYB2iBOLqSblbVV2ig=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -15533,7 +15533,7 @@
     "@kui-shell/plugin-codeflare": {
       "version": "file:plugins/plugin-codeflare",
       "requires": {
-        "@guidebooks/store": "^7.4.6",
+        "@guidebooks/store": "^7.4.7",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.18",
         "@patternfly/react-core": "^4.276.6",

--- a/plugins/plugin-codeflare/package.json
+++ b/plugins/plugin-codeflare/package.json
@@ -30,7 +30,7 @@
     "@types/split2": "^3.2.1"
   },
   "dependencies": {
-    "@guidebooks/store": "^7.4.6",
+    "@guidebooks/store": "^7.4.7",
     "@logdna/tail-file": "^3.0.1",
     "@patternfly/react-charts": "^6.94.18",
     "@patternfly/react-core": "^4.276.6",


### PR DESCRIPTION
* further improvements to helm install with relative workdir ([79bd176](https://github.com/guidebooks/store/commit/79bd176484267bc4f9e54818f7101b5e0beaa3ae))
* improved support for installing and running torchx on 3.9.6 on macOS ([1bea28f](https://github.com/guidebooks/store/commit/1bea28f020b8d4b0aedbdebadc78d031438172e5))