### PR TITLE
fix: further improvements to ray log streaming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -500,9 +500,9 @@
       "license": "MIT"
     },
     "node_modules/@guidebooks/store": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.6.1.tgz",
-      "integrity": "sha512-v85Ff5i5plhVrBBEGGj7GJyZ6iUvdLTQ+2JwVOYQ5sOueN3Pi8rv5uBkygEefPToa5KL8TDEXu2Ff3jdAp5BmQ=="
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.6.3.tgz",
+      "integrity": "sha512-YP3NYJVzu4GguvwqN3gs1N0+5cSgGHLa5XE1NFcqXutjyDkurMYYaecTjWzogw2mF2dPLmMNVJL9cGTRxmJ8IQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -13678,7 +13678,7 @@
     },
     "plugins/plugin-client-default": {
       "name": "@kui-shell/plugin-client",
-      "version": "4.7.1",
+      "version": "4.7.2",
       "license": "Apache-2.0"
     },
     "plugins/plugin-codeflare": {
@@ -13686,7 +13686,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^7.6.1",
+        "@guidebooks/store": "^7.6.3",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.19",
         "@patternfly/react-core": "^4.276.8",
@@ -14370,9 +14370,9 @@
       "dev": true
     },
     "@guidebooks/store": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.6.1.tgz",
-      "integrity": "sha512-v85Ff5i5plhVrBBEGGj7GJyZ6iUvdLTQ+2JwVOYQ5sOueN3Pi8rv5uBkygEefPToa5KL8TDEXu2Ff3jdAp5BmQ=="
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.6.3.tgz",
+      "integrity": "sha512-YP3NYJVzu4GguvwqN3gs1N0+5cSgGHLa5XE1NFcqXutjyDkurMYYaecTjWzogw2mF2dPLmMNVJL9cGTRxmJ8IQ=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -14606,7 +14606,7 @@
     "@kui-shell/plugin-codeflare": {
       "version": "file:plugins/plugin-codeflare",
       "requires": {
-        "@guidebooks/store": "^7.6.1",
+        "@guidebooks/store": "^7.6.3",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.19",
         "@patternfly/react-core": "^4.276.8",

--- a/plugins/plugin-codeflare/package.json
+++ b/plugins/plugin-codeflare/package.json
@@ -30,7 +30,7 @@
     "@types/split2": "^3.2.1"
   },
   "dependencies": {
-    "@guidebooks/store": "^7.6.1",
+    "@guidebooks/store": "^7.6.3",
     "@logdna/tail-file": "^3.0.1",
     "@patternfly/react-charts": "^6.94.19",
     "@patternfly/react-core": "^4.276.8",

--- a/tests/kind/run.sh
+++ b/tests/kind/run.sh
@@ -243,7 +243,7 @@ function test {
     
     # 4. validate the output of the job itself
     echo "[Test] Validating run output"
-    if grep -q Succeeded $OUTPUT ; then
+    if grep -iq Succeeded $OUTPUT ; then
         echo "[Test] ✅ Job submit output seems good!"
     else
         echo "[Test] ❌ Job submit output seems incomplete: $OUTPUT"

--- a/tests/self-test/self-test.yaml
+++ b/tests/self-test/self-test.yaml
@@ -9,7 +9,7 @@ metadata:
   name: codeflare-self-test-role
 rules:
 - apiGroups: [""]
-  resources: ["pods", "pods/exec", "services", "events", "serviceaccounts", "configmaps"]
+  resources: ["pods", "pods/exec", "pods/log", "services", "events", "serviceaccounts", "configmaps"]
   verbs: ["create", "delete", "get", "watch", "list"]
 - apiGroups: [""]
   resources: ["secrets"]


### PR DESCRIPTION
- use websocat on the head node
- use ray job logs, on the head node, to synchronize with job completion
- avoid any use of stdin bindings on the client side
- continue avoiding websocat installation on the client side