### PR TITLE
fix: force yoga.wasm to be loaded as a file resource

### DIFF
--- a/plugins/plugin-codeflare-dashboard/package.json
+++ b/plugins/plugin-codeflare-dashboard/package.json
@@ -35,5 +35,14 @@
     "pretty-bytes": "^6.1.0",
     "pretty-ms": "^8.0.0",
     "strip-ansi": "^7.0.1"
+  },
+  "kui": {
+    "webpack": {
+      "rules": {
+        "file-loader": [
+          "yoga\\.wasm$"
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
it turns out that `yoga-wasm-web` does something silly with the way it loads the wasm; rather than a simple `import('./yoga.wasm')` it does some gymnastics that include a `readFile`, thus assuming the wasm is a file, not a more general module. so this change adds a webpack rule that forces just yoga.wasm to be treated as a file resource.