### PR TITLE
fix: improve cpu utilization metrics, and retry on ray head initContainer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -500,9 +500,9 @@
       "license": "MIT"
     },
     "node_modules/@guidebooks/store": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.10.4.tgz",
-      "integrity": "sha512-CRF2cNpPbmrlRkyd5H6WtG5ziHf0t12EqpadXtiohW8Fa/AmS8CettHvRgHz7UmP/uldZxheNCLMRZ0XylOehg=="
+      "version": "7.10.5",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.10.5.tgz",
+      "integrity": "sha512-eG2KfM8ol5i4fyQsXfZahpyl+lW7miq6iPvdz7W4oZfNBcIsF10WKBq4MVkTwPWdMdg+zGWKq66l+hzEgF15Gg=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -13771,7 +13771,7 @@
     },
     "plugins/plugin-client-default": {
       "name": "@kui-shell/plugin-client",
-      "version": "4.12.2",
+      "version": "4.12.3",
       "license": "Apache-2.0"
     },
     "plugins/plugin-codeflare": {
@@ -13779,7 +13779,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^7.10.4",
+        "@guidebooks/store": "^7.10.5",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.19",
         "@patternfly/react-core": "^4.276.8",
@@ -14408,9 +14408,9 @@
       "dev": true
     },
     "@guidebooks/store": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.10.4.tgz",
-      "integrity": "sha512-CRF2cNpPbmrlRkyd5H6WtG5ziHf0t12EqpadXtiohW8Fa/AmS8CettHvRgHz7UmP/uldZxheNCLMRZ0XylOehg=="
+      "version": "7.10.5",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.10.5.tgz",
+      "integrity": "sha512-eG2KfM8ol5i4fyQsXfZahpyl+lW7miq6iPvdz7W4oZfNBcIsF10WKBq4MVkTwPWdMdg+zGWKq66l+hzEgF15Gg=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -14644,7 +14644,7 @@
     "@kui-shell/plugin-codeflare": {
       "version": "file:plugins/plugin-codeflare",
       "requires": {
-        "@guidebooks/store": "^7.10.4",
+        "@guidebooks/store": "^7.10.5",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.19",
         "@patternfly/react-core": "^4.276.8",

--- a/plugins/plugin-codeflare/package.json
+++ b/plugins/plugin-codeflare/package.json
@@ -30,7 +30,7 @@
     "@types/split2": "^3.2.1"
   },
   "dependencies": {
-    "@guidebooks/store": "^7.10.4",
+    "@guidebooks/store": "^7.10.5",
     "@logdna/tail-file": "^3.0.1",
     "@patternfly/react-charts": "^6.94.19",
     "@patternfly/react-core": "^4.276.8",


### PR DESCRIPTION
* cpu utilization information may be bogus; switch to cgroup-based stats ([a409a7e](https://github.com/guidebooks/store/commit/a409a7ed556aed5265a95d7a1f7150da21030bbd))
* increase max log requests for app logs ([3d5ca5c](https://github.com/guidebooks/store/commit/3d5ca5cf46a849745c92d6bd5c07f8f0a49112f8))
* ray head wait-for-workers initContainer should retry if wait fails ([2ab27b6](https://github.com/guidebooks/store/commit/2ab27b6c8c27a6d567fd954aa3c0eb8a1b49abf4))