### PR TITLE
fix: more EOF protection fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -500,9 +500,9 @@
       "license": "MIT"
     },
     "node_modules/@guidebooks/store": {
-      "version": "7.10.6",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.10.6.tgz",
-      "integrity": "sha512-IsCAUYmIkhrBuJwaGjRjR7dmPQVyTZ6qa877NY8ZZmT3MFgmWIPGARQ//ooDrHgqFTfT9sAF2j7I3yr/gS0Unw=="
+      "version": "7.10.7",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.10.7.tgz",
+      "integrity": "sha512-uKvU5/cRGPvXwIcHCacSrhW0h3fvXBYoPIpWMu/sWnHBsQeayCMniZTlVqgIR4lAsjTvPvwN9uYrKc+L6YgEnQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -13771,7 +13771,7 @@
     },
     "plugins/plugin-client-default": {
       "name": "@kui-shell/plugin-client",
-      "version": "4.12.4",
+      "version": "4.12.5",
       "license": "Apache-2.0"
     },
     "plugins/plugin-codeflare": {
@@ -13779,7 +13779,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^7.10.6",
+        "@guidebooks/store": "^7.10.7",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.19",
         "@patternfly/react-core": "^4.276.8",
@@ -14408,9 +14408,9 @@
       "dev": true
     },
     "@guidebooks/store": {
-      "version": "7.10.6",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.10.6.tgz",
-      "integrity": "sha512-IsCAUYmIkhrBuJwaGjRjR7dmPQVyTZ6qa877NY8ZZmT3MFgmWIPGARQ//ooDrHgqFTfT9sAF2j7I3yr/gS0Unw=="
+      "version": "7.10.7",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.10.7.tgz",
+      "integrity": "sha512-uKvU5/cRGPvXwIcHCacSrhW0h3fvXBYoPIpWMu/sWnHBsQeayCMniZTlVqgIR4lAsjTvPvwN9uYrKc+L6YgEnQ=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -14644,7 +14644,7 @@
     "@kui-shell/plugin-codeflare": {
       "version": "file:plugins/plugin-codeflare",
       "requires": {
-        "@guidebooks/store": "^7.10.6",
+        "@guidebooks/store": "^7.10.7",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.19",
         "@patternfly/react-core": "^4.276.8",

--- a/plugins/plugin-codeflare/package.json
+++ b/plugins/plugin-codeflare/package.json
@@ -30,7 +30,7 @@
     "@types/split2": "^3.2.1"
   },
   "dependencies": {
-    "@guidebooks/store": "^7.10.6",
+    "@guidebooks/store": "^7.10.7",
     "@logdna/tail-file": "^3.0.1",
     "@patternfly/react-charts": "^6.94.19",
     "@patternfly/react-core": "^4.276.8",


### PR DESCRIPTION
custodian should detect head pod existence
logs/via-exec shouldn't bother to tee to local file