### PR TITLE
feat: bump to `@guidebooks/store@8`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -500,9 +500,9 @@
       "license": "MIT"
     },
     "node_modules/@guidebooks/store": {
-      "version": "7.10.7",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.10.7.tgz",
-      "integrity": "sha512-uKvU5/cRGPvXwIcHCacSrhW0h3fvXBYoPIpWMu/sWnHBsQeayCMniZTlVqgIR4lAsjTvPvwN9uYrKc+L6YgEnQ=="
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-8.0.0.tgz",
+      "integrity": "sha512-lYMcKyDv8Nz79CVU0//1agzjsywJpGGccdS6P0DyH6Ip0FlqG4Nx89RSjgiGrC7x2Yeo/thgvHcQvzNhxQmMOA=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -13771,7 +13771,7 @@
     },
     "plugins/plugin-client-default": {
       "name": "@kui-shell/plugin-client",
-      "version": "4.12.5",
+      "version": "4.12.6",
       "license": "Apache-2.0"
     },
     "plugins/plugin-codeflare": {
@@ -13779,7 +13779,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@guidebooks/store": "^7.10.7",
+        "@guidebooks/store": "^8.0.0",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.19",
         "@patternfly/react-core": "^4.276.8",
@@ -14408,9 +14408,9 @@
       "dev": true
     },
     "@guidebooks/store": {
-      "version": "7.10.7",
-      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-7.10.7.tgz",
-      "integrity": "sha512-uKvU5/cRGPvXwIcHCacSrhW0h3fvXBYoPIpWMu/sWnHBsQeayCMniZTlVqgIR4lAsjTvPvwN9uYrKc+L6YgEnQ=="
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@guidebooks/store/-/store-8.0.0.tgz",
+      "integrity": "sha512-lYMcKyDv8Nz79CVU0//1agzjsywJpGGccdS6P0DyH6Ip0FlqG4Nx89RSjgiGrC7x2Yeo/thgvHcQvzNhxQmMOA=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -14644,7 +14644,7 @@
     "@kui-shell/plugin-codeflare": {
       "version": "file:plugins/plugin-codeflare",
       "requires": {
-        "@guidebooks/store": "^7.10.7",
+        "@guidebooks/store": "^8.0.0",
         "@logdna/tail-file": "^3.0.1",
         "@patternfly/react-charts": "^6.94.19",
         "@patternfly/react-core": "^4.276.8",

--- a/plugins/plugin-codeflare/package.json
+++ b/plugins/plugin-codeflare/package.json
@@ -30,7 +30,7 @@
     "@types/split2": "^3.2.1"
   },
   "dependencies": {
-    "@guidebooks/store": "^7.10.7",
+    "@guidebooks/store": "^8.0.0",
     "@logdna/tail-file": "^3.0.1",
     "@patternfly/react-charts": "^6.94.19",
     "@patternfly/react-core": "^4.276.8",


### PR DESCRIPTION
BREAKING CHANGE: this pulls in new apis for the multi-cluster app dispatcher

It also pulls in torchx 0.6.0 (was 0.5.0)

# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->